### PR TITLE
Add curated POE data sync and planner enrichment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# POE
+# Path of Exile MCP static data
+
+This repository packages a lightweight knowledge base that powers the
+`poe_mcp_server` helpers for Path of Exile crafting planning.  Curated JSON
+snapshots live under [`data/`](data/) and are loaded at runtime via the
+[`poe_mcp_server.datasources`](poe_mcp_server/datasources) package.  The primary
+consumer is [`assemble_crafting_plan`](poe_mcp_server/planner.py), which
+augments free-form crafting steps with map boss unlocks, harvest crafts,
+essence details, and bench recipe metadata.
+
+## Curated datasets
+
+The sync script stores the following files inside [`data/`](data/):
+
+* `bench_recipes.json` – Master crafting bench options, including translated
+  modifier text, bench tiers, supported item classes, action keywords, and
+  exact crafting costs.
+* `essences.json` – Essence tiers, minimum area level, and the translated
+  modifiers they apply when used on an item.
+* `harvest_crafts.json` – Harvest crafting options with their groups, tags, and
+  any class restrictions to help match augment/remove actions.
+* `bosses.json` – Atlas boss encounters and map boss metadata (map tier,
+  resident bosses, and unlock requirements when available).
+
+These JSON documents are consumed via thin loaders in
+`poe_mcp_server/datasources/`.  Each loader normalises the text for fuzzy
+matching so planner calls such as
+`assemble_crafting_plan(["Run Maven's Crucible"])` automatically append the
+relevant context to the returned `CraftingStep` objects.
+
+## Sync workflow
+
+The curated data is regenerated with
+[`scripts/sync_static_data.py`](scripts/sync_static_data.py).  The script pulls
+live data from the PoE Wiki and the RePoE project to ensure the knowledge base
+stays current across leagues.
+
+1. Ensure Python 3.10+ is available and install the only runtime dependency:
+   ```bash
+   pip install requests
+   ```
+2. Run the sync script from the repository root.  Without arguments it refreshes
+   every dataset:
+   ```bash
+   python scripts/sync_static_data.py
+   ```
+3. To shorten reruns while iterating you can limit the sections.  For example,
+   regenerate the boss dataset after tweaking keyword logic:
+   ```bash
+   python scripts/sync_static_data.py --sections bosses
+   ```
+4. Inspect the updated files under `data/` (e.g. spot-check that
+   `bosses.json` unlock strings look clean) and commit the refreshed JSON along
+   with code changes.
+
+Each invocation rewrites the JSON files in-place.  Because the script relies on
+external services, expect the boss export to take a couple of minutes while it
+requests individual wiki pages.  Re-run the sync whenever GGG launches a new
+league or the upstream data sources publish balance updates.
+
+## Developing against the planner
+
+When new knowledge is synced, no additional steps are needed for the planner:
+`poe_mcp_server.datasources.utils.load_json` reads directly from `data/` and the
+`assemble_crafting_plan` helper automatically surfaces the richer instructions.
+If you expand the planner with new action keywords, add the necessary curated
+fields to the sync script and rerun it so the JSON stays in lockstep with the
+code.

--- a/data/bench_recipes.json
+++ b/data/bench_recipes.json
@@ -1,0 +1,21154 @@
+[
+  {
+    "action": "change_socket_count",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Jeweller's Orb"
+      }
+    ],
+    "description": "Set number of sockets to 2",
+    "display": "Set number of sockets to 2",
+    "identifier": "Jun, Veiled Master::Set number of sockets to 2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "socket",
+      "2-socket"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "change_socket_count",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Jeweller's Orb"
+      }
+    ],
+    "description": "Set number of sockets to 3",
+    "display": "Set number of sockets to 3",
+    "identifier": "Jun, Veiled Master::Set number of sockets to 3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "socket",
+      "3-socket"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "change_socket_count",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 10,
+        "currency": "Jeweller's Orb"
+      }
+    ],
+    "description": "Set number of sockets to 4",
+    "display": "Set number of sockets to 4",
+    "identifier": "Jun, Veiled Master::Set number of sockets to 4",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "socket",
+      "4-socket"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "change_socket_count",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 70,
+        "currency": "Jeweller's Orb"
+      }
+    ],
+    "description": "Set number of sockets to 5",
+    "display": "Set number of sockets to 5",
+    "identifier": "Jun, Veiled Master::Set number of sockets to 5",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "socket",
+      "5-socket"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "change_socket_count",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 350,
+        "currency": "Jeweller's Orb"
+      }
+    ],
+    "description": "Set number of sockets to 6",
+    "display": "Set number of sockets to 6",
+    "identifier": "Jun, Veiled Master::Set number of sockets to 6",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "socket",
+      "6-socket"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "link_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Fusing"
+      }
+    ],
+    "description": "Link 2 sockets",
+    "display": "Link 2 sockets",
+    "identifier": "Jun, Veiled Master::Link 2 sockets",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "link",
+      "2-link"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "link_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Fusing"
+      }
+    ],
+    "description": "Link 3 sockets",
+    "display": "Link 3 sockets",
+    "identifier": "Jun, Veiled Master::Link 3 sockets",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "link",
+      "3-link"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "link_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Orb of Fusing"
+      }
+    ],
+    "description": "Link 4 sockets",
+    "display": "Link 4 sockets",
+    "identifier": "Jun, Veiled Master::Link 4 sockets",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "link",
+      "4-link"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "link_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 150,
+        "currency": "Orb of Fusing"
+      }
+    ],
+    "description": "Link 5 sockets",
+    "display": "Link 5 sockets",
+    "identifier": "Jun, Veiled Master::Link 5 sockets",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "link",
+      "5-link"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "link_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1500,
+        "currency": "Orb of Fusing"
+      }
+    ],
+    "description": "Link 6 sockets",
+    "display": "Link 6 sockets",
+    "identifier": "Jun, Veiled Master::Link 6 sockets",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "link",
+      "6-link"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a red socket",
+    "display": "Force a red socket",
+    "identifier": "Jun, Veiled Master::Force a red socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "colour",
+      "red"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 25,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a RR socket",
+    "display": "Force a RR socket",
+    "identifier": "Jun, Veiled Master::Force a RR socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "RR"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 120,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a RRR socket",
+    "display": "Force a RRR socket",
+    "identifier": "Jun, Veiled Master::Force a RRR socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "RRR"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a green socket",
+    "display": "Force a green socket",
+    "identifier": "Jun, Veiled Master::Force a green socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "colour",
+      "green"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 25,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a GG socket",
+    "display": "Force a GG socket",
+    "identifier": "Jun, Veiled Master::Force a GG socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "GG"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 120,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a GGG socket",
+    "display": "Force a GGG socket",
+    "identifier": "Jun, Veiled Master::Force a GGG socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "GGG"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a blue socket",
+    "display": "Force a blue socket",
+    "identifier": "Jun, Veiled Master::Force a blue socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "colour",
+      "blue"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 25,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a BB socket",
+    "display": "Force a BB socket",
+    "identifier": "Jun, Veiled Master::Force a BB socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "BB"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 120,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a BBB socket",
+    "display": "Force a BBB socket",
+    "identifier": "Jun, Veiled Master::Force a BBB socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "BBB"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 15,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a RG socket",
+    "display": "Force a RG socket",
+    "identifier": "Jun, Veiled Master::Force a RG socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "RG"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 15,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a RB socket",
+    "display": "Force a RB socket",
+    "identifier": "Jun, Veiled Master::Force a RB socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "RB"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 15,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a GB socket",
+    "display": "Force a GB socket",
+    "identifier": "Jun, Veiled Master::Force a GB socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "GB"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 100,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a RRG socket",
+    "display": "Force a RRG socket",
+    "identifier": "Jun, Veiled Master::Force a RRG socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "RRG"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 100,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a RRB socket",
+    "display": "Force a RRB socket",
+    "identifier": "Jun, Veiled Master::Force a RRB socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "RRB"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 100,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a GGR socket",
+    "display": "Force a GGR socket",
+    "identifier": "Jun, Veiled Master::Force a GGR socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "GGR"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 100,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a GGB socket",
+    "display": "Force a GGB socket",
+    "identifier": "Jun, Veiled Master::Force a GGB socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "GGB"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 100,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a BBG socket",
+    "display": "Force a BBG socket",
+    "identifier": "Jun, Veiled Master::Force a BBG socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "BBG"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "color_sockets",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 100,
+        "currency": "Chromatic Orb"
+      }
+    ],
+    "description": "Force a BBR socket",
+    "display": "Force a BBR socket",
+    "identifier": "Jun, Veiled Master::Force a BBR socket",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "colour",
+      "BBR"
+    ],
+    "master": "Jun, Veiled Master"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+15-25 to maximum Life",
+    "display": "+15-25 to maximum Life",
+    "identifier": "HelenaMasterIncreasedLife1",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamasterincreasedlife1",
+      "+15-25 to maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+16-20% to Fire Resistance",
+    "display": "+16-20% to Fire Resistance",
+    "identifier": "HelenaMasterFireResist1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamasterfireresist1",
+      "+16-20% to fire resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+16-20% to Cold Resistance",
+    "display": "+16-20% to Cold Resistance",
+    "identifier": "HelenaMasterColdResist1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamastercoldresist1_",
+      "+16-20% to cold resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+16-20% to Lightning Resistance",
+    "display": "+16-20% to Lightning Resistance",
+    "identifier": "HelenaMasterLightningResist1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamasterlightningresist1",
+      "+16-20% to lightning resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+15-20 to Strength",
+    "display": "+15-20 to Strength",
+    "identifier": "HelenaMasterStrength1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamasterstrength1",
+      "+15-20 to strength"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+15-20 to Dexterity",
+    "display": "+15-20 to Dexterity",
+    "identifier": "HelenaMasterDexterity1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamasterdexterity1",
+      "+15-20 to dexterity"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+15-20 to Intelligence",
+    "display": "+15-20 to Intelligence",
+    "identifier": "HelenaMasterIntelligence1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "helenamasterintelligence1",
+      "+15-20 to intelligence"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "remove_crafted_mods",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Scouring"
+      }
+    ],
+    "description": "Remove crafted modifiers",
+    "display": "Remove crafted modifiers",
+    "identifier": "Niko, Master of the Depths::Remove crafted modifiers",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "remove crafted",
+      "craft remove"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-28% to Fire Resistance",
+    "display": "+21-28% to Fire Resistance",
+    "identifier": "EinharMasterFireResist2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireresist2",
+      "+21-28% to fire resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+29-35% to Fire Resistance",
+    "display": "+29-35% to Fire Resistance",
+    "identifier": "EinharMasterFireResist3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireresist3_",
+      "+29-35% to fire resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-28% to Cold Resistance",
+    "display": "+21-28% to Cold Resistance",
+    "identifier": "EinharMasterColdResist2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmastercoldresist2",
+      "+21-28% to cold resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+29-35% to Cold Resistance",
+    "display": "+29-35% to Cold Resistance",
+    "identifier": "EinharMasterColdResist3__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmastercoldresist3__",
+      "+29-35% to cold resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-28% to Lightning Resistance",
+    "display": "+21-28% to Lightning Resistance",
+    "identifier": "EinharMasterLightningResist2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterlightningresist2",
+      "+21-28% to lightning resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+29-35% to Lightning Resistance",
+    "display": "+29-35% to Lightning Resistance",
+    "identifier": "EinharMasterLightningResist3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterlightningresist3_",
+      "+29-35% to lightning resistance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+10-12% to Fire and Cold Resistances",
+    "display": "+10-12% to Fire and Cold Resistances",
+    "identifier": "EinharMasterFireAndColdResist1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireandcoldresist1",
+      "+10-12% to fire and cold resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+13-16% to Fire and Cold Resistances",
+    "display": "+13-16% to Fire and Cold Resistances",
+    "identifier": "EinharMasterFireAndColdResist2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireandcoldresist2",
+      "+13-16% to fire and cold resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+17-20% to Fire and Cold Resistances",
+    "display": "+17-20% to Fire and Cold Resistances",
+    "identifier": "EinharMasterFireAndColdResist3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireandcoldresist3",
+      "+17-20% to fire and cold resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+10-12% to Cold and Lightning Resistances",
+    "display": "+10-12% to Cold and Lightning Resistances",
+    "identifier": "EinharMasterColdAndLightningResist1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmastercoldandlightningresist1_",
+      "+10-12% to cold and lightning resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+13-16% to Cold and Lightning Resistances",
+    "display": "+13-16% to Cold and Lightning Resistances",
+    "identifier": "EinharMasterColdAndLightningResist2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmastercoldandlightningresist2",
+      "+13-16% to cold and lightning resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+17-20% to Cold and Lightning Resistances",
+    "display": "+17-20% to Cold and Lightning Resistances",
+    "identifier": "EinharMasterColdAndLightningResist3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmastercoldandlightningresist3_",
+      "+17-20% to cold and lightning resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+10-12% to Fire and Lightning Resistances",
+    "display": "+10-12% to Fire and Lightning Resistances",
+    "identifier": "EinharMasterFireAndLightningResist1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireandlightningresist1",
+      "+10-12% to fire and lightning resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+13-16% to Fire and Lightning Resistances",
+    "display": "+13-16% to Fire and Lightning Resistances",
+    "identifier": "EinharMasterFireAndLightningResist2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireandlightningresist2",
+      "+13-16% to fire and lightning resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+17-20% to Fire and Lightning Resistances",
+    "display": "+17-20% to Fire and Lightning Resistances",
+    "identifier": "EinharMasterFireAndLightningResist3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterfireandlightningresist3_",
+      "+17-20% to fire and lightning resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+5-8% to all Elemental Resistances",
+    "display": "+5-8% to all Elemental Resistances",
+    "identifier": "EinharMasterAllResist1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterallresist1",
+      "+5-8% to all elemental resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+9-12% to all Elemental Resistances",
+    "display": "+9-12% to all Elemental Resistances",
+    "identifier": "EinharMasterAllResist2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterallresist2",
+      "+9-12% to all elemental resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+4-6% to all Elemental Resistances; Minions have +5-8% to all Elemental Resistances",
+    "display": "+4-6% to all Elemental Resistances; Minions have +5-8% to all Elemental Resistances",
+    "identifier": "EinharMasterAllResistMinionResist1_",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterallresistminionresist1_",
+      "+4-6% to all elemental resistances",
+      "minions have +5-8% to all elemental resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+7-9% to all Elemental Resistances; Minions have +9-12% to all Elemental Resistances",
+    "display": "+7-9% to all Elemental Resistances; Minions have +9-12% to all Elemental Resistances",
+    "identifier": "EinharMasterAllResistMinionResist2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterallresistminionresist2",
+      "+7-9% to all elemental resistances",
+      "minions have +9-12% to all elemental resistances"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-25 to Strength",
+    "display": "+21-25 to Strength",
+    "identifier": "EinharMasterStrength2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterstrength2",
+      "+21-25 to strength"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+26-30 to Strength",
+    "display": "+26-30 to Strength",
+    "identifier": "EinharMasterStrength3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterstrength3",
+      "+26-30 to strength"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-25 to Dexterity",
+    "display": "+21-25 to Dexterity",
+    "identifier": "EinharMasterDexterity2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterdexterity2",
+      "+21-25 to dexterity"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+26-30 to Dexterity",
+    "display": "+26-30 to Dexterity",
+    "identifier": "EinharMasterDexterity3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterdexterity3",
+      "+26-30 to dexterity"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-25 to Intelligence",
+    "display": "+21-25 to Intelligence",
+    "identifier": "EinharMasterIntelligence2__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterintelligence2__",
+      "+21-25 to intelligence"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+26-30 to Intelligence",
+    "display": "+26-30 to Intelligence",
+    "identifier": "EinharMasterIntelligence3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterintelligence3",
+      "+26-30 to intelligence"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "+6-9 to all Attributes",
+    "display": "+6-9 to all Attributes",
+    "identifier": "EinharMasterAllAttributes1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterallattributes1",
+      "+6-9 to all attributes"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "+10-13 to all Attributes",
+    "display": "+10-13 to all Attributes",
+    "identifier": "EinharMasterAllAttributes2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterallattributes2",
+      "+10-13 to all attributes"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "10-14% increased Movement Speed",
+    "display": "10-14% increased Movement Speed",
+    "identifier": "EinharMasterMovementVelocity1",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "einharmastermovementvelocity1",
+      "10-14% increased movement speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "15-19% increased Movement Speed",
+    "display": "15-19% increased Movement Speed",
+    "identifier": "EinharMasterMovementVelocity2",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "einharmastermovementvelocity2",
+      "15-19% increased movement speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "20-24% increased Movement Speed",
+    "display": "20-24% increased Movement Speed",
+    "identifier": "EinharMasterMovementVelocity3",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "einharmastermovementvelocity3",
+      "20-24% increased movement speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+26-40 to maximum Life",
+    "display": "+26-40 to maximum Life",
+    "identifier": "EinharMasterIncreasedLife2",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterincreasedlife2",
+      "+26-40 to maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+41-55 to maximum Life",
+    "display": "+41-55 to maximum Life",
+    "identifier": "EinharMasterIncreasedLife3",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterincreasedlife3",
+      "+41-55 to maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 4,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+56-70 to maximum Life",
+    "display": "+56-70 to maximum Life",
+    "identifier": "EinharMasterIncreasedLife4",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterincreasedlife4",
+      "+56-70 to maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 5,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+71-85 to maximum Life",
+    "display": "+71-85 to maximum Life",
+    "identifier": "EinharMasterIncreasedLife5_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "einharmasterincreasedlife5_",
+      "+71-85 to maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "30-50% of Physical Attack Damage Leeched as Life",
+    "display": "30-50% of Physical Attack Damage Leeched as Life",
+    "identifier": "EinharMasterLifeLeechFromAttacksPermyriad1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterlifeleechfromattackspermyriad1",
+      "30-50% of physical attack damage leeched as life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "60-80% of Physical Attack Damage Leeched as Life",
+    "display": "60-80% of Physical Attack Damage Leeched as Life",
+    "identifier": "EinharMasterLifeLeechFromAttacksPermyriad2",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterlifeleechfromattackspermyriad2",
+      "60-80% of physical attack damage leeched as life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "30-50% of Physical Attack Damage Leeched as Life",
+    "display": "30-50% of Physical Attack Damage Leeched as Life",
+    "identifier": "EinharMasterLocalLifeLeechPermyriad1__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocallifeleechpermyriad1__",
+      "30-50% of physical attack damage leeched as life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "50-80% of Physical Attack Damage Leeched as Life",
+    "display": "50-80% of Physical Attack Damage Leeched as Life",
+    "identifier": "EinharMasterLocalLifeLeechPermyriad2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterlocallifeleechpermyriad2",
+      "50-80% of physical attack damage leeched as life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "20-40% of Physical Attack Damage Leeched as Mana",
+    "display": "20-40% of Physical Attack Damage Leeched as Mana",
+    "identifier": "EinharMasterLocalManaLeechPermyriad1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalmanaleechpermyriad1",
+      "20-40% of physical attack damage leeched as mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+55-64 to maximum Mana",
+    "display": "+55-64 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaTwoHandWeapon1___",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanatwohandweapon1___",
+      "+55-64 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+65-74 to maximum Mana",
+    "display": "+65-74 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaTwoHandWeapon2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanatwohandweapon2_",
+      "+65-74 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+75-84 to maximum Mana",
+    "display": "+75-84 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaTwoHandWeapon3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanatwohandweapon3_",
+      "+75-84 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 4,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+85-94 to maximum Mana",
+    "display": "+85-94 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaTwoHandWeapon4",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanatwohandweapon4",
+      "+85-94 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+35-44 to maximum Mana",
+    "display": "+35-44 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaWeapon1__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanaweapon1__",
+      "+35-44 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+45-54 to maximum Mana",
+    "display": "+45-54 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaWeapon2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanaweapon2",
+      "+45-54 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+55-64 to maximum Mana",
+    "display": "+55-64 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaWeapon3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanaweapon3_",
+      "+55-64 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 4,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+65-74 to maximum Mana",
+    "display": "+65-74 to maximum Mana",
+    "identifier": "EinharMasterIncreasedManaWeapon4",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterincreasedmanaweapon4",
+      "+65-74 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+25-34 to maximum Mana",
+    "display": "+25-34 to maximum Mana",
+    "identifier": "EinharMasterIncreasedMana1",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterincreasedmana1",
+      "+25-34 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+35-44 to maximum Mana",
+    "display": "+35-44 to maximum Mana",
+    "identifier": "EinharMasterIncreasedMana2",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterincreasedmana2",
+      "+35-44 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+45-54 to maximum Mana",
+    "display": "+45-54 to maximum Mana",
+    "identifier": "EinharMasterIncreasedMana3",
+    "item_classes": [
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterincreasedmana3",
+      "+45-54 to maximum mana"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "20-30% increased Mana Regeneration Rate",
+    "display": "20-30% increased Mana Regeneration Rate",
+    "identifier": "EinharMasterManaRegeneration1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Ring",
+      "Amulet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmastermanaregeneration1",
+      "20-30% increased mana regeneration rate"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "31-40% increased Mana Regeneration Rate",
+    "display": "31-40% increased Mana Regeneration Rate",
+    "identifier": "EinharMasterManaRegeneration2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Ring",
+      "Amulet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmastermanaregeneration2",
+      "31-40% increased mana regeneration rate"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "No Physical Damage",
+    "display": "No Physical Damage",
+    "identifier": "EinharMasterLocalIncreasedPhysicalDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedphysicaldamage1",
+      "no physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "No Physical Damage",
+    "display": "No Physical Damage",
+    "identifier": "EinharMasterLocalIncreasedPhysicalDamage2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedphysicaldamage2_",
+      "no physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage",
+    "display": "No Physical Damage",
+    "identifier": "EinharMasterLocalIncreasedPhysicalDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedphysicaldamage3",
+      "no physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 4,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "No Physical Damage",
+    "display": "No Physical Damage",
+    "identifier": "EinharMasterLocalIncreasedPhysicalDamage4___",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedphysicaldamage4___",
+      "no physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "37-51% increased Spell Damage",
+    "display": "37-51% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnTwoHandWeapon1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelldamageontwohandweapon1",
+      "37-51% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "52-66% increased Spell Damage",
+    "display": "52-66% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnTwoHandWeapon2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelldamageontwohandweapon2",
+      "52-66% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "67-81% increased Spell Damage",
+    "display": "67-81% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnTwoHandWeapon3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelldamageontwohandweapon3",
+      "67-81% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 4,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "82-99% increased Spell Damage",
+    "display": "82-99% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnTwoHandWeapon4_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelldamageontwohandweapon4_",
+      "82-99% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "25-34% increased Spell Damage",
+    "display": "25-34% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnWeapon1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelldamageonweapon1_",
+      "25-34% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "35-44% increased Spell Damage",
+    "display": "35-44% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnWeapon2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelldamageonweapon2",
+      "35-44% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "45-54% increased Spell Damage",
+    "display": "45-54% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnWeapon3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelldamageonweapon3",
+      "45-54% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 4,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "55-66% increased Spell Damage",
+    "display": "55-66% increased Spell Damage",
+    "identifier": "EinharMasterSpellDamageOnWeapon4",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelldamageonweapon4",
+      "55-66% increased spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "11-20% increased Damage over Time",
+    "display": "11-20% increased Damage over Time",
+    "identifier": "EinharMasterDegenerationDamage1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterdegenerationdamage1_",
+      "11-20% increased damage over time"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "21-30% increased Damage over Time",
+    "display": "21-30% increased Damage over Time",
+    "identifier": "EinharMasterDegenerationDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterdegenerationdamage2",
+      "21-30% increased damage over time"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "15-23% increased Elemental Damage with Attack Skills",
+    "display": "15-23% increased Elemental Damage with Attack Skills",
+    "identifier": "EinharMasterWeaponElementalDamage1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasterweaponelementaldamage1_",
+      "15-23% increased elemental damage with attack skills"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "24-32% increased Elemental Damage with Attack Skills",
+    "display": "24-32% increased Elemental Damage with Attack Skills",
+    "identifier": "EinharMasterWeaponElementalDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Quiver",
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterweaponelementaldamage2",
+      "24-32% increased elemental damage with attack skills"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "8-10% increased Attack Speed",
+    "display": "8-10% increased Attack Speed",
+    "identifier": "EinharMasterLocalIncreasedAttackSpeed1__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedattackspeed1__",
+      "8-10% increased attack speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-15% increased Attack Speed",
+    "display": "11-15% increased Attack Speed",
+    "identifier": "EinharMasterLocalIncreasedAttackSpeed2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedattackspeed2_",
+      "11-15% increased attack speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "16-20% increased Attack Speed",
+    "display": "16-20% increased Attack Speed",
+    "identifier": "EinharMasterLocalIncreasedAttackSpeed3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedattackspeed3",
+      "16-20% increased attack speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "11-13% increased Attack Speed",
+    "display": "11-13% increased Attack Speed",
+    "identifier": "EinharMasterLocalIncreasedAttackSpeedRanged3",
+    "item_classes": [
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalincreasedattackspeedranged3",
+      "11-13% increased attack speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "7-12% increased Attack Speed",
+    "display": "7-12% increased Attack Speed",
+    "identifier": "EinharMasterAttackSpeed1",
+    "item_classes": [
+      "Gloves",
+      "Quiver",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterattackspeed1",
+      "7-12% increased attack speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "15-20% increased Cast Speed",
+    "display": "15-20% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeedTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeedtwohand1",
+      "15-20% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "21-26% increased Cast Speed",
+    "display": "21-26% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeedTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeedtwohand2",
+      "21-26% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "27-32% increased Cast Speed",
+    "display": "27-32% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeedTwoHand3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeedtwohand3_",
+      "27-32% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "10-13% increased Cast Speed",
+    "display": "10-13% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeed1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeed1",
+      "10-13% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "14-17% increased Cast Speed",
+    "display": "14-17% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeed2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeed2",
+      "14-17% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "18-21% increased Cast Speed",
+    "display": "18-21% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeed3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeed3",
+      "18-21% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "37-51% increased Fire Damage",
+    "display": "37-51% increased Fire Damage",
+    "identifier": "EinharMasterFireDamageTwoHandPrefix1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterfiredamagetwohandprefix1",
+      "37-51% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "52-66% increased Fire Damage",
+    "display": "52-66% increased Fire Damage",
+    "identifier": "EinharMasterFireDamageTwoHandPrefix2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterfiredamagetwohandprefix2",
+      "52-66% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "67-81% increased Fire Damage",
+    "display": "67-81% increased Fire Damage",
+    "identifier": "EinharMasterFireDamageTwoHandPrefix3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterfiredamagetwohandprefix3",
+      "67-81% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "25-34% increased Fire Damage",
+    "display": "25-34% increased Fire Damage",
+    "identifier": "EinharMasterFireDamagePrefix1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterfiredamageprefix1_",
+      "25-34% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "35-44% increased Fire Damage",
+    "display": "35-44% increased Fire Damage",
+    "identifier": "EinharMasterFireDamagePrefix2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterfiredamageprefix2",
+      "35-44% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "45-54% increased Fire Damage",
+    "display": "45-54% increased Fire Damage",
+    "identifier": "EinharMasterFireDamagePrefix3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterfiredamageprefix3_",
+      "45-54% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "9-12% increased Fire Damage",
+    "display": "9-12% increased Fire Damage",
+    "identifier": "EinharMasterFireDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterfiredamage1",
+      "9-12% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-16% increased Fire Damage",
+    "display": "13-16% increased Fire Damage",
+    "identifier": "EinharMasterFireDamage2_",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterfiredamage2_",
+      "13-16% increased fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "37-51% increased Cold Damage",
+    "display": "37-51% increased Cold Damage",
+    "identifier": "EinharMasterColdDamageTwoHandPrefix1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmastercolddamagetwohandprefix1",
+      "37-51% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "52-66% increased Cold Damage",
+    "display": "52-66% increased Cold Damage",
+    "identifier": "EinharMasterColdDamageTwoHandPrefix2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmastercolddamagetwohandprefix2",
+      "52-66% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "67-81% increased Cold Damage",
+    "display": "67-81% increased Cold Damage",
+    "identifier": "EinharMasterColdDamageTwoHandPrefix3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmastercolddamagetwohandprefix3",
+      "67-81% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "25-34% increased Cold Damage",
+    "display": "25-34% increased Cold Damage",
+    "identifier": "EinharMasterColdDamagePrefix1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastercolddamageprefix1",
+      "25-34% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "35-44% increased Cold Damage",
+    "display": "35-44% increased Cold Damage",
+    "identifier": "EinharMasterColdDamagePrefix2__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastercolddamageprefix2__",
+      "35-44% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "45-54% increased Cold Damage",
+    "display": "45-54% increased Cold Damage",
+    "identifier": "EinharMasterColdDamagePrefix3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastercolddamageprefix3_",
+      "45-54% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "9-12% increased Cold Damage",
+    "display": "9-12% increased Cold Damage",
+    "identifier": "EinharMasterColdDamage1_",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastercolddamage1_",
+      "9-12% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-16% increased Cold Damage",
+    "display": "13-16% increased Cold Damage",
+    "identifier": "EinharMasterColdDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastercolddamage2",
+      "13-16% increased cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "37-51% increased Lightning Damage",
+    "display": "37-51% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamageTwoHandPrefix1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterlightningdamagetwohandprefix1",
+      "37-51% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "52-66% increased Lightning Damage",
+    "display": "52-66% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamageTwoHandPrefix2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterlightningdamagetwohandprefix2",
+      "52-66% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "67-81% increased Lightning Damage",
+    "display": "67-81% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamageTwoHandPrefix3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterlightningdamagetwohandprefix3",
+      "67-81% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "25-34% increased Lightning Damage",
+    "display": "25-34% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamagePrefix1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlightningdamageprefix1",
+      "25-34% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "35-44% increased Lightning Damage",
+    "display": "35-44% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamagePrefix2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlightningdamageprefix2",
+      "35-44% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "45-54% increased Lightning Damage",
+    "display": "45-54% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamagePrefix3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlightningdamageprefix3",
+      "45-54% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "9-12% increased Lightning Damage",
+    "display": "9-12% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlightningdamage1",
+      "9-12% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-16% increased Lightning Damage",
+    "display": "13-16% increased Lightning Damage",
+    "identifier": "EinharMasterLightningDamage2_",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlightningdamage2_",
+      "13-16% increased lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "37-51% increased Chaos Damage",
+    "display": "37-51% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamageTwoHandPrefix1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterchaosdamagetwohandprefix1",
+      "37-51% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "52-66% increased Chaos Damage",
+    "display": "52-66% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamageTwoHandPrefix2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterchaosdamagetwohandprefix2",
+      "52-66% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "67-81% increased Chaos Damage",
+    "display": "67-81% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamageTwoHandPrefix3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterchaosdamagetwohandprefix3_",
+      "67-81% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "25-34% increased Chaos Damage",
+    "display": "25-34% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamagePrefix1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterchaosdamageprefix1",
+      "25-34% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "35-44% increased Chaos Damage",
+    "display": "35-44% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamagePrefix2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterchaosdamageprefix2",
+      "35-44% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "45-54% increased Chaos Damage",
+    "display": "45-54% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamagePrefix3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterchaosdamageprefix3",
+      "45-54% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "9-12% increased Chaos Damage",
+    "display": "9-12% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterchaosdamage1",
+      "9-12% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-16% increased Chaos Damage",
+    "display": "13-16% increased Chaos Damage",
+    "identifier": "EinharMasterChaosDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterchaosdamage2",
+      "13-16% increased chaos damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+91-120 to Accuracy Rating",
+    "display": "+91-120 to Accuracy Rating",
+    "identifier": "EinharMasterLocalAccuracyRating1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalaccuracyrating1",
+      "+91-120 to accuracy rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+121-200 to Accuracy Rating",
+    "display": "+121-200 to Accuracy Rating",
+    "identifier": "EinharMasterLocalAccuracyRating2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalaccuracyrating2",
+      "+121-200 to accuracy rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+201-300 to Accuracy Rating",
+    "display": "+201-300 to Accuracy Rating",
+    "identifier": "EinharMasterLocalAccuracyRating3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalaccuracyrating3",
+      "+201-300 to accuracy rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+91-120 to Accuracy Rating",
+    "display": "+91-120 to Accuracy Rating",
+    "identifier": "EinharMasterAccuracyRating1",
+    "item_classes": [
+      "Gloves",
+      "Helmet",
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasteraccuracyrating1",
+      "+91-120 to accuracy rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+121-150 to Accuracy Rating",
+    "display": "+121-150 to Accuracy Rating",
+    "identifier": "EinharMasterAccuracyRating2_",
+    "item_classes": [
+      "Gloves",
+      "Helmet",
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasteraccuracyrating2_",
+      "+121-150 to accuracy rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+151-220 to Accuracy Rating",
+    "display": "+151-220 to Accuracy Rating",
+    "identifier": "EinharMasterAccuracyRating3",
+    "item_classes": [
+      "Gloves",
+      "Helmet",
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasteraccuracyrating3",
+      "+151-220 to accuracy rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "9-12% increased Global Physical Damage",
+    "display": "9-12% increased Global Physical Damage",
+    "identifier": "EinharMasterPhysicalDamage1_",
+    "item_classes": [
+      "Shield",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterphysicaldamage1_",
+      "9-12% increased global physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-16% increased Global Physical Damage",
+    "display": "13-16% increased Global Physical Damage",
+    "identifier": "EinharMasterPhysicalDamage2",
+    "item_classes": [
+      "Shield",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterphysicaldamage2",
+      "13-16% increased global physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "26-35% increased Armour",
+    "display": "26-35% increased Armour",
+    "identifier": "EinharMasterArmourPercent1_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourpercent1_",
+      "26-35% increased armour"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "41-50% increased Armour",
+    "display": "41-50% increased Armour",
+    "identifier": "EinharMasterArmourPercent2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourpercent2",
+      "41-50% increased armour"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "56-74% increased Armour",
+    "display": "56-74% increased Armour",
+    "identifier": "EinharMasterArmourPercent3_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourpercent3_",
+      "56-74% increased armour"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+50-75 to Armour",
+    "display": "+50-75 to Armour",
+    "identifier": "EinharMasterFlatArmour1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatarmour1",
+      "+50-75 to armour"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+100-150 to Armour",
+    "display": "+100-150 to Armour",
+    "identifier": "EinharMasterFlatArmour2_",
+    "item_classes": [
+      "Body Armour",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatarmour2_",
+      "+100-150 to armour"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+250-320 to Armour",
+    "display": "+250-320 to Armour",
+    "identifier": "EinharMasterFlatArmour3",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatarmour3",
+      "+250-320 to armour"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "26-35% increased Evasion Rating",
+    "display": "26-35% increased Evasion Rating",
+    "identifier": "EinharMasterEvasionPercent1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterevasionpercent1",
+      "26-35% increased evasion rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "41-50% increased Evasion Rating",
+    "display": "41-50% increased Evasion Rating",
+    "identifier": "EinharMasterEvasionPercent2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterevasionpercent2",
+      "41-50% increased evasion rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "56-74% increased Evasion Rating",
+    "display": "56-74% increased Evasion Rating",
+    "identifier": "EinharMasterEvasionPercent3",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterevasionpercent3",
+      "56-74% increased evasion rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+50-75 to Evasion Rating",
+    "display": "+50-75 to Evasion Rating",
+    "identifier": "EinharMasterFlatEvasion1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatevasion1",
+      "+50-75 to evasion rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+100-150 to Evasion Rating",
+    "display": "+100-150 to Evasion Rating",
+    "identifier": "EinharMasterFlatEvasion2",
+    "item_classes": [
+      "Body Armour",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatevasion2",
+      "+100-150 to evasion rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+250-320 to Evasion Rating",
+    "display": "+250-320 to Evasion Rating",
+    "identifier": "EinharMasterFlatEvasion3",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatevasion3",
+      "+250-320 to evasion rating"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "26-35% increased Energy Shield",
+    "display": "26-35% increased Energy Shield",
+    "identifier": "EinharMasterEnergyShieldPercent1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterenergyshieldpercent1",
+      "26-35% increased energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "41-50% increased Energy Shield",
+    "display": "41-50% increased Energy Shield",
+    "identifier": "EinharMasterEnergyShieldPercent2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterenergyshieldpercent2",
+      "41-50% increased energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "56-74% increased Energy Shield",
+    "display": "56-74% increased Energy Shield",
+    "identifier": "EinharMasterEnergyShieldPercent3_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterenergyshieldpercent3_",
+      "56-74% increased energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+17-22 to maximum Energy Shield",
+    "display": "+17-22 to maximum Energy Shield",
+    "identifier": "EinharMasterFlatEnergyShield1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatenergyshield1",
+      "+17-22 to maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+35-45 to maximum Energy Shield",
+    "display": "+35-45 to maximum Energy Shield",
+    "identifier": "EinharMasterFlatEnergyShield2",
+    "item_classes": [
+      "Body Armour",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatenergyshield2",
+      "+35-45 to maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+56-69 to maximum Energy Shield",
+    "display": "+56-69 to maximum Energy Shield",
+    "identifier": "EinharMasterFlatEnergyShield3",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterflatenergyshield3",
+      "+56-69 to maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "10-12% increased maximum Energy Shield",
+    "display": "10-12% increased maximum Energy Shield",
+    "identifier": "EinharMasterGlobalEnergyShield1",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterglobalenergyshield1",
+      "10-12% increased maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "13-15% increased maximum Energy Shield",
+    "display": "13-15% increased maximum Energy Shield",
+    "identifier": "EinharMasterGlobalEnergyShield2",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterglobalenergyshield2",
+      "13-15% increased maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+21-25 to maximum Energy Shield",
+    "display": "+21-25 to maximum Energy Shield",
+    "identifier": "EinharMasterMaximumEnergyShield1_",
+    "item_classes": [
+      "Amulet",
+      "Ring"
+    ],
+    "keywords": [
+      "einharmastermaximumenergyshield1_",
+      "+21-25 to maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+26-30 to maximum Energy Shield",
+    "display": "+26-30 to maximum Energy Shield",
+    "identifier": "EinharMasterMaximumEnergyShield2_",
+    "item_classes": [
+      "Amulet",
+      "Ring"
+    ],
+    "keywords": [
+      "einharmastermaximumenergyshield2_",
+      "+26-30 to maximum energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "26-35% increased Armour and Evasion",
+    "display": "26-35% increased Armour and Evasion",
+    "identifier": "EinharMasterArmourAndEvasionPercent1_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourandevasionpercent1_",
+      "26-35% increased armour and evasion"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "41-50% increased Armour and Evasion",
+    "display": "41-50% increased Armour and Evasion",
+    "identifier": "EinharMasterArmourAndEvasionPercent2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourandevasionpercent2",
+      "41-50% increased armour and evasion"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "56-74% increased Armour and Evasion",
+    "display": "56-74% increased Armour and Evasion",
+    "identifier": "EinharMasterArmourAndEvasionPercent3",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourandevasionpercent3",
+      "56-74% increased armour and evasion"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "26-35% increased Armour and Energy Shield",
+    "display": "26-35% increased Armour and Energy Shield",
+    "identifier": "EinharMasterArmourAndEnergyShieldPercent1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourandenergyshieldpercent1",
+      "26-35% increased armour and energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "41-50% increased Armour and Energy Shield",
+    "display": "41-50% increased Armour and Energy Shield",
+    "identifier": "EinharMasterArmourAndEnergyShieldPercent2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourandenergyshieldpercent2",
+      "41-50% increased armour and energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "56-74% increased Armour and Energy Shield",
+    "display": "56-74% increased Armour and Energy Shield",
+    "identifier": "EinharMasterArmourAndEnergyShieldPercent3_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterarmourandenergyshieldpercent3_",
+      "56-74% increased armour and energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "26-35% increased Evasion and Energy Shield",
+    "display": "26-35% increased Evasion and Energy Shield",
+    "identifier": "EinharMasterEvasionAndEnergyShieldPercent1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterevasionandenergyshieldpercent1",
+      "26-35% increased evasion and energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "41-50% increased Evasion and Energy Shield",
+    "display": "41-50% increased Evasion and Energy Shield",
+    "identifier": "EinharMasterEvasionAndEnergyShieldPercent2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterevasionandenergyshieldpercent2",
+      "41-50% increased evasion and energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "56-74% increased Evasion and Energy Shield",
+    "display": "56-74% increased Evasion and Energy Shield",
+    "identifier": "EinharMasterEvasionAndEnergyShieldPercent3",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterevasionandenergyshieldpercent3",
+      "56-74% increased evasion and energy shield"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 19-21 to 32-41 Fire Damage",
+    "display": "Adds 19-21 to 32-41 Fire Damage",
+    "identifier": "EinharMasterLocalFireDamageTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalfiredamagetwohand1",
+      "adds 19-21 to 32-41 fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 38-46 to 73-85 Fire Damage",
+    "display": "Adds 38-46 to 73-85 Fire Damage",
+    "identifier": "EinharMasterLocalFireDamageTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalfiredamagetwohand2",
+      "adds 38-46 to 73-85 fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 60-72 to 110-128 Fire Damage",
+    "display": "Adds 60-72 to 110-128 Fire Damage",
+    "identifier": "EinharMasterLocalFireDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalfiredamagetwohand3",
+      "adds 60-72 to 110-128 fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 11-12 to 19-23 Fire Damage",
+    "display": "Adds 11-12 to 19-23 Fire Damage",
+    "identifier": "EinharMasterLocalFireDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalfiredamage1",
+      "adds 11-12 to 19-23 fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 22-27 to 42-49 Fire Damage",
+    "display": "Adds 22-27 to 42-49 Fire Damage",
+    "identifier": "EinharMasterLocalFireDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalfiredamage2",
+      "adds 22-27 to 42-49 fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 35-41 to 63-73 Fire Damage",
+    "display": "Adds 35-41 to 63-73 Fire Damage",
+    "identifier": "EinharMasterLocalFireDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalfiredamage3",
+      "adds 35-41 to 63-73 fire damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 8-11 to 16-20 Fire Damage to Attacks",
+    "display": "Adds 8-11 to 16-20 Fire Damage to Attacks",
+    "identifier": "EinharMasterAddedFireDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteraddedfiredamage1",
+      "adds 8-11 to 16-20 fire damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 12-17 to 26-30 Fire Damage to Attacks",
+    "display": "Adds 12-17 to 26-30 Fire Damage to Attacks",
+    "identifier": "EinharMasterAddedFireDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasteraddedfiredamage2",
+      "adds 12-17 to 26-30 fire damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 19-21 to 32-41 Cold Damage",
+    "display": "Adds 19-21 to 32-41 Cold Damage",
+    "identifier": "EinharMasterLocalColdDamageTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalcolddamagetwohand1",
+      "adds 19-21 to 32-41 cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 38-46 to 73-85 Cold Damage",
+    "display": "Adds 38-46 to 73-85 Cold Damage",
+    "identifier": "EinharMasterLocalColdDamageTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalcolddamagetwohand2",
+      "adds 38-46 to 73-85 cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 60-72 to 110-128 Cold Damage",
+    "display": "Adds 60-72 to 110-128 Cold Damage",
+    "identifier": "EinharMasterLocalColdDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalcolddamagetwohand3",
+      "adds 60-72 to 110-128 cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 11-12 to 19-23 Cold Damage",
+    "display": "Adds 11-12 to 19-23 Cold Damage",
+    "identifier": "EinharMasterLocalColdDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalcolddamage1",
+      "adds 11-12 to 19-23 cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 22-27 to 42-49 Cold Damage",
+    "display": "Adds 22-27 to 42-49 Cold Damage",
+    "identifier": "EinharMasterLocalColdDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalcolddamage2",
+      "adds 22-27 to 42-49 cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 35-41 to 63-73 Cold Damage",
+    "display": "Adds 35-41 to 63-73 Cold Damage",
+    "identifier": "EinharMasterLocalColdDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalcolddamage3",
+      "adds 35-41 to 63-73 cold damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 6-8 to 14-18 Cold Damage to Attacks",
+    "display": "Adds 6-8 to 14-18 Cold Damage to Attacks",
+    "identifier": "EinharMasterAddedColdDamage1_",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteraddedcolddamage1_",
+      "adds 6-8 to 14-18 cold damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 11-15 to 23-27 Cold Damage to Attacks",
+    "display": "Adds 11-15 to 23-27 Cold Damage to Attacks",
+    "identifier": "EinharMasterAddedColdDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasteraddedcolddamage2",
+      "adds 11-15 to 23-27 cold damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 2-5 to 46-64 Lightning Damage",
+    "display": "Adds 2-5 to 46-64 Lightning Damage",
+    "identifier": "EinharMasterLocalLightningDamageTwoHand1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocallightningdamagetwohand1_",
+      "adds 2-5 to 46-64 lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 6-9 to 104-139 Lightning Damage",
+    "display": "Adds 6-9 to 104-139 Lightning Damage",
+    "identifier": "EinharMasterLocalLightningDamageTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocallightningdamagetwohand2",
+      "adds 6-9 to 104-139 lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 10-14 to 162-197 Lightning Damage",
+    "display": "Adds 10-14 to 162-197 Lightning Damage",
+    "identifier": "EinharMasterLocalLightningDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocallightningdamagetwohand3",
+      "adds 10-14 to 162-197 lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 1-3 to 27-37 Lightning Damage",
+    "display": "Adds 1-3 to 27-37 Lightning Damage",
+    "identifier": "EinharMasterLocalLightningDamage1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocallightningdamage1_",
+      "adds 1-3 to 27-37 lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 3-5 to 60-80 Lightning Damage",
+    "display": "Adds 3-5 to 60-80 Lightning Damage",
+    "identifier": "EinharMasterLocalLightningDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocallightningdamage2",
+      "adds 3-5 to 60-80 lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 6-8 to 100-113 Lightning Damage",
+    "display": "Adds 6-8 to 100-113 Lightning Damage",
+    "identifier": "EinharMasterLocalLightningDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocallightningdamage3",
+      "adds 6-8 to 100-113 lightning damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 1-4 to 32-36 Lightning Damage to Attacks",
+    "display": "Adds 1-4 to 32-36 Lightning Damage to Attacks",
+    "identifier": "EinharMasterAddedLightningDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteraddedlightningdamage1",
+      "adds 1-4 to 32-36 lightning damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 1-5 to 41-48 Lightning Damage to Attacks",
+    "display": "Adds 1-5 to 41-48 Lightning Damage to Attacks",
+    "identifier": "EinharMasterAddedLightningDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasteraddedlightningdamage2",
+      "adds 1-5 to 41-48 lightning damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 9-12 to 18-21 Physical Damage",
+    "display": "Adds 9-12 to 18-21 Physical Damage",
+    "identifier": "EinharMasterLocalPhysicalDamageTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalphysicaldamagetwohand1",
+      "adds 9-12 to 18-21 physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 11-15 to 23-27 Physical Damage",
+    "display": "Adds 11-15 to 23-27 Physical Damage",
+    "identifier": "EinharMasterLocalPhysicalDamageTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalphysicaldamagetwohand2",
+      "adds 11-15 to 23-27 physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 18-24 to 36-42 Physical Damage",
+    "display": "Adds 18-24 to 36-42 Physical Damage",
+    "identifier": "EinharMasterLocalPhysicalDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalphysicaldamagetwohand3",
+      "adds 18-24 to 36-42 physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 6-8 to 13-15 Physical Damage",
+    "display": "Adds 6-8 to 13-15 Physical Damage",
+    "identifier": "EinharMasterLocalPhysicalDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalphysicaldamage1",
+      "adds 6-8 to 13-15 physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 7-11 to 16-19 Physical Damage",
+    "display": "Adds 7-11 to 16-19 Physical Damage",
+    "identifier": "EinharMasterLocalPhysicalDamage2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalphysicaldamage2_",
+      "adds 7-11 to 16-19 physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 13-17 to 26-30 Physical Damage",
+    "display": "Adds 13-17 to 26-30 Physical Damage",
+    "identifier": "EinharMasterLocalPhysicalDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterlocalphysicaldamage3",
+      "adds 13-17 to 26-30 physical damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 3-5 to 6-8 Physical Damage to Attacks",
+    "display": "Adds 3-5 to 6-8 Physical Damage to Attacks",
+    "identifier": "EinharMasterAddedPhysicalDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteraddedphysicaldamage1",
+      "adds 3-5 to 6-8 physical damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 5-7 to 8-10 Physical Damage to Attacks",
+    "display": "Adds 5-7 to 8-10 Physical Damage to Attacks",
+    "identifier": "EinharMasterAddedPhysicalDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedphysicaldamage2",
+      "adds 5-7 to 8-10 physical damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 6-8 to 14-18 Chaos Damage to Attacks",
+    "display": "Adds 6-8 to 14-18 Chaos Damage to Attacks",
+    "identifier": "EinharMasterAddedChaosDamage1",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Quiver",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteraddedchaosdamage1",
+      "adds 6-8 to 14-18 chaos damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 11-15 to 23-27 Chaos Damage to Attacks",
+    "display": "Adds 11-15 to 23-27 Chaos Damage to Attacks",
+    "identifier": "EinharMasterAddedChaosDamage2",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedchaosdamage2",
+      "adds 11-15 to 23-27 chaos damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 16-21 to 31-36 Fire Damage to Spells",
+    "display": "Adds 16-21 to 31-36 Fire Damage to Spells",
+    "identifier": "EinharMasterSpellAddedFireDamageTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedfiredamagetwohand1",
+      "adds 16-21 to 31-36 fire damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 28-38 to 57-66 Fire Damage to Spells",
+    "display": "Adds 28-38 to 57-66 Fire Damage to Spells",
+    "identifier": "EinharMasterSpellAddedFireDamageTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedfiredamagetwohand2",
+      "adds 28-38 to 57-66 fire damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 41-55 to 83-96 Fire Damage to Spells",
+    "display": "Adds 41-55 to 83-96 Fire Damage to Spells",
+    "identifier": "EinharMasterSpellAddedFireDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedfiredamagetwohand3",
+      "adds 41-55 to 83-96 fire damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 12-16 to 23-27 Fire Damage to Spells",
+    "display": "Adds 12-16 to 23-27 Fire Damage to Spells",
+    "identifier": "EinharMasterSpellAddedFireDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedfiredamage1",
+      "adds 12-16 to 23-27 fire damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 21-28 to 42-49 Fire Damage to Spells",
+    "display": "Adds 21-28 to 42-49 Fire Damage to Spells",
+    "identifier": "EinharMasterSpellAddedFireDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedfiredamage2",
+      "adds 21-28 to 42-49 fire damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 31-41 to 61-71 Fire Damage to Spells",
+    "display": "Adds 31-41 to 61-71 Fire Damage to Spells",
+    "identifier": "EinharMasterSpellAddedFireDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedfiredamage3",
+      "adds 31-41 to 61-71 fire damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 14-19 to 28-33 Cold Damage to Spells",
+    "display": "Adds 14-19 to 28-33 Cold Damage to Spells",
+    "identifier": "EinharMasterSpellAddedColdDamageTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedcolddamagetwohand1",
+      "adds 14-19 to 28-33 cold damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 26-34 to 52-60 Cold Damage to Spells",
+    "display": "Adds 26-34 to 52-60 Cold Damage to Spells",
+    "identifier": "EinharMasterSpellAddedColdDamageTwoHand2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedcolddamagetwohand2_",
+      "adds 26-34 to 52-60 cold damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 38-50 to 75-88 Cold Damage to Spells",
+    "display": "Adds 38-50 to 75-88 Cold Damage to Spells",
+    "identifier": "EinharMasterSpellAddedColdDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedcolddamagetwohand3",
+      "adds 38-50 to 75-88 cold damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 10-13 to 19-22 Cold Damage to Spells",
+    "display": "Adds 10-13 to 19-22 Cold Damage to Spells",
+    "identifier": "EinharMasterSpellAddedColdDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedcolddamage1",
+      "adds 10-13 to 19-22 cold damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 17-23 to 34-40 Cold Damage to Spells",
+    "display": "Adds 17-23 to 34-40 Cold Damage to Spells",
+    "identifier": "EinharMasterSpellAddedColdDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedcolddamage2",
+      "adds 17-23 to 34-40 cold damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 25-33 to 50-58 Cold Damage to Spells",
+    "display": "Adds 25-33 to 50-58 Cold Damage to Spells",
+    "identifier": "EinharMasterSpellAddedColdDamage3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedcolddamage3",
+      "adds 25-33 to 50-58 cold damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 1-5 to 59-63 Lightning Damage to Spells",
+    "display": "Adds 1-5 to 59-63 Lightning Damage to Spells",
+    "identifier": "EinharMasterSpellAddedLightningDamageTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedlightningdamagetwohand1",
+      "adds 1-5 to 59-63 lightning damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 3-9 to 109-115 Lightning Damage to Spells",
+    "display": "Adds 3-9 to 109-115 Lightning Damage to Spells",
+    "identifier": "EinharMasterSpellAddedLightningDamageTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedlightningdamagetwohand2",
+      "adds 3-9 to 109-115 lightning damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 4-13 to 159-168 Lightning Damage to Spells",
+    "display": "Adds 4-13 to 159-168 Lightning Damage to Spells",
+    "identifier": "EinharMasterSpellAddedLightningDamageTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmasterspelladdedlightningdamagetwohand3",
+      "adds 4-13 to 159-168 lightning damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 1-4 to 39-42 Lightning Damage to Spells",
+    "display": "Adds 1-4 to 39-42 Lightning Damage to Spells",
+    "identifier": "EinharMasterSpellAddedLightningDamage1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedlightningdamage1",
+      "adds 1-4 to 39-42 lightning damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 2-6 to 73-77 Lightning Damage to Spells",
+    "display": "Adds 2-6 to 73-77 Lightning Damage to Spells",
+    "identifier": "EinharMasterSpellAddedLightningDamage2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedlightningdamage2",
+      "adds 2-6 to 73-77 lightning damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 3-9 to 106-112 Lightning Damage to Spells",
+    "display": "Adds 3-9 to 106-112 Lightning Damage to Spells",
+    "identifier": "EinharMasterSpellAddedLightningDamage3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterspelladdedlightningdamage3_",
+      "adds 3-9 to 106-112 lightning damage to spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "17-19% increased Critical Strike Chance",
+    "display": "17-19% increased Critical Strike Chance",
+    "identifier": "EinharMasterLocalCriticalStrikeChance1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalcriticalstrikechance1_",
+      "17-19% increased critical strike chance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "20-24% increased Critical Strike Chance",
+    "display": "20-24% increased Critical Strike Chance",
+    "identifier": "EinharMasterLocalCriticalStrikeChance2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalcriticalstrikechance2",
+      "20-24% increased critical strike chance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "25-27% increased Critical Strike Chance",
+    "display": "25-27% increased Critical Strike Chance",
+    "identifier": "EinharMasterLocalCriticalStrikeChance3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterlocalcriticalstrikechance3_",
+      "25-27% increased critical strike chance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+17-19% to Global Critical Strike Multiplier",
+    "display": "+17-19% to Global Critical Strike Multiplier",
+    "identifier": "EinharMasterCriticalStrikeMultiplier1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikemultiplier1",
+      "+17-19% to global critical strike multiplier"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+20-24% to Global Critical Strike Multiplier",
+    "display": "+20-24% to Global Critical Strike Multiplier",
+    "identifier": "EinharMasterCriticalStrikeMultiplier2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikemultiplier2",
+      "+20-24% to global critical strike multiplier"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+25-28% to Global Critical Strike Multiplier",
+    "display": "+25-28% to Global Critical Strike Multiplier",
+    "identifier": "EinharMasterCriticalStrikeMultiplier3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikemultiplier3",
+      "+25-28% to global critical strike multiplier"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "45-75% increased Critical Strike Chance for Spells",
+    "display": "45-75% increased Critical Strike Chance for Spells",
+    "identifier": "EinharMasterCriticalStrikeChanceSpells2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikechancespells2h1",
+      "45-75% increased critical strike chance for spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "76-105% increased Critical Strike Chance for Spells",
+    "display": "76-105% increased Critical Strike Chance for Spells",
+    "identifier": "EinharMasterCriticalStrikeChanceSpells2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikechancespells2h2_",
+      "76-105% increased critical strike chance for spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "30-49% increased Critical Strike Chance for Spells",
+    "display": "30-49% increased Critical Strike Chance for Spells",
+    "identifier": "EinharMasterCriticalStrikeChanceSpells1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikechancespells1",
+      "30-49% increased critical strike chance for spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "50-69% increased Critical Strike Chance for Spells",
+    "display": "50-69% increased Critical Strike Chance for Spells",
+    "identifier": "EinharMasterCriticalStrikeChanceSpells2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastercriticalstrikechancespells2",
+      "50-69% increased critical strike chance for spells"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 9,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "17-21% increased Global Critical Strike Chance",
+    "display": "17-21% increased Global Critical Strike Chance",
+    "identifier": "EinharMasterGlobalCriticalStrikeChance1",
+    "item_classes": [
+      "Quiver",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterglobalcriticalstrikechance1",
+      "17-21% increased global critical strike chance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "22-27% increased Global Critical Strike Chance",
+    "display": "22-27% increased Global Critical Strike Chance",
+    "identifier": "EinharMasterGlobalCriticalStrikeChance2",
+    "item_classes": [
+      "Quiver",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterglobalcriticalstrikechance2",
+      "22-27% increased global critical strike chance"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "5-10% increased Flask Effect Duration",
+    "display": "5-10% increased Flask Effect Duration",
+    "identifier": "EinharMasterFlaskEffectDuration1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterflaskeffectduration1",
+      "5-10% increased flask effect duration"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "11-15% increased Flask Effect Duration",
+    "display": "11-15% increased Flask Effect Duration",
+    "identifier": "EinharMasterFlaskEffectDuration2",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterflaskeffectduration2",
+      "11-15% increased flask effect duration"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "15-20% chance to Avoid being Stunned",
+    "display": "15-20% chance to Avoid being Stunned",
+    "identifier": "EinharMasterAvoidStun1",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteravoidstun1",
+      "15-20% chance to avoid being stunned"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "21-25% chance to Avoid being Stunned",
+    "display": "21-25% chance to Avoid being Stunned",
+    "identifier": "EinharMasterAvoidStun2",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasteravoidstun2",
+      "21-25% chance to avoid being stunned"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "16-20% chance to Avoid Elemental Ailments",
+    "display": "16-20% chance to Avoid Elemental Ailments",
+    "identifier": "EinharMasterAvoidElementalAilments1",
+    "item_classes": [
+      "Boots",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasteravoidelementalailments1",
+      "16-20% chance to avoid elemental ailments"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "21-25% chance to Avoid Elemental Ailments",
+    "display": "21-25% chance to Avoid Elemental Ailments",
+    "identifier": "EinharMasterAvoidElementalAilments2_",
+    "item_classes": [
+      "Boots",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasteravoidelementalailments2_",
+      "21-25% chance to avoid elemental ailments"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "-30--24% increased Effect of Chill and Shock on you",
+    "display": "-30--24% increased Effect of Chill and Shock on you",
+    "identifier": "EinharMasterReducedElementalAilmentEffect1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasterreducedelementalailmenteffect1",
+      "-30--24% increased effect of chill and shock on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "-40--31% increased Effect of Chill and Shock on you",
+    "display": "-40--31% increased Effect of Chill and Shock on you",
+    "identifier": "EinharMasterReducedElementalAilmentEffect2_",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasterreducedelementalailmenteffect2_",
+      "-40--31% increased effect of chill and shock on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 9,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+2-3% Chance to Block",
+    "display": "+2-3% Chance to Block",
+    "identifier": "EinharMasterShieldAttackBlock1",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "einharmastershieldattackblock1",
+      "+2-3% chance to block"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+4-5% Chance to Block",
+    "display": "+4-5% Chance to Block",
+    "identifier": "EinharMasterShieldAttackBlock2",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "einharmastershieldattackblock2",
+      "+4-5% chance to block"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "2-3% Chance to Block Spell Damage",
+    "display": "2-3% Chance to Block Spell Damage",
+    "identifier": "EinharMasterShieldSpellBlock1",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "einharmastershieldspellblock1",
+      "2-3% chance to block spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "4-5% Chance to Block Spell Damage",
+    "display": "4-5% Chance to Block Spell Damage",
+    "identifier": "EinharMasterShieldSpellBlock2",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "einharmastershieldspellblock2",
+      "4-5% chance to block spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "5-6% increased Life Regeneration rate",
+    "display": "5-6% increased Life Regeneration rate",
+    "identifier": "EinharMasterLifeRegenerationRate1",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasterliferegenerationrate1",
+      "5-6% increased life regeneration rate"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "7-8% increased Life Regeneration rate",
+    "display": "7-8% increased Life Regeneration rate",
+    "identifier": "EinharMasterLifeRegenerationRate2_",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasterliferegenerationrate2_",
+      "7-8% increased life regeneration rate"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "2% additional Physical Damage Reduction",
+    "display": "2% additional Physical Damage Reduction",
+    "identifier": "EinharMasterReducedPhysicalDamageTaken1",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterreducedphysicaldamagetaken1",
+      "2% additional physical damage reduction"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "3% additional Physical Damage Reduction",
+    "display": "3% additional Physical Damage Reduction",
+    "identifier": "EinharMasterReducedPhysicalDamageTaken2___",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterreducedphysicaldamagetaken2___",
+      "3% additional physical damage reduction"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+3-4% chance to Suppress Spell Damage",
+    "display": "+3-4% chance to Suppress Spell Damage",
+    "identifier": "EinharMasterChanceToSuppressSpells1_",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasterchancetosuppressspells1_",
+      "+3-4% chance to suppress spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+5-6% chance to Suppress Spell Damage",
+    "display": "+5-6% chance to Suppress Spell Damage",
+    "identifier": "EinharMasterChanceToSuppressSpells2",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasterchancetosuppressspells2",
+      "+5-6% chance to suppress spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+5-7% chance to Suppress Spell Damage",
+    "display": "+5-7% chance to Suppress Spell Damage",
+    "identifier": "EinharMasterChanceToSuppressSpellsHigh1",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterchancetosuppressspellshigh1",
+      "+5-7% chance to suppress spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+8-10% chance to Suppress Spell Damage",
+    "display": "+8-10% chance to Suppress Spell Damage",
+    "identifier": "EinharMasterChanceToSuppressSpellsHigh2",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterchancetosuppressspellshigh2",
+      "+8-10% chance to suppress spell damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-11% increased Energy Shield Recharge Rate",
+    "display": "9-11% increased Energy Shield Recharge Rate",
+    "identifier": "EinharMasterEnergyShieldRegeneration1___",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasterenergyshieldregeneration1___",
+      "9-11% increased energy shield recharge rate"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "12-14% increased Energy Shield Recharge Rate",
+    "display": "12-14% increased Energy Shield Recharge Rate",
+    "identifier": "EinharMasterEnergyShieldRegeneration2",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasterenergyshieldregeneration2",
+      "12-14% increased energy shield recharge rate"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "16-20% faster start of Energy Shield Recharge",
+    "display": "16-20% faster start of Energy Shield Recharge",
+    "identifier": "EinharMasterEnergyShieldDelay1_",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterenergyshielddelay1_",
+      "16-20% faster start of energy shield recharge"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "21-25% faster start of Energy Shield Recharge",
+    "display": "21-25% faster start of Energy Shield Recharge",
+    "identifier": "EinharMasterEnergyShieldDelay2",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterenergyshielddelay2",
+      "21-25% faster start of energy shield recharge"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "-5% increased Damage taken from Damage Over Time",
+    "display": "-5% increased Damage taken from Damage Over Time",
+    "identifier": "EinharMasterReducedDamageOverTimeTaken1",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterreduceddamageovertimetaken1",
+      "-5% increased damage taken from damage over time"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Item drops on Death if Equipped by an Animated Guardian",
+    "display": "Item drops on Death if Equipped by an Animated Guardian",
+    "identifier": "EinharMasterItemDropsOnGuardianDeath1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "einharmasteritemdropsonguardiandeath1",
+      "item drops on death if equipped by an animated guardian"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Light Radius is based on Energy Shield instead of Life",
+    "display": "Light Radius is based on Energy Shield instead of Life",
+    "identifier": "EinharMasterLightRadiusScalesWithEnergyShield1",
+    "item_classes": [
+      "Helmet",
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterlightradiusscaleswithenergyshield1",
+      "light radius is based on energy shield instead of life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "Minions have 11-15% increased maximum Life",
+    "display": "Minions have 11-15% increased maximum Life",
+    "identifier": "EinharMasterMinionLife1",
+    "item_classes": [
+      "Shield",
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterminionlife1",
+      "minions have 11-15% increased maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions have 16-20% increased maximum Life",
+    "display": "Minions have 16-20% increased maximum Life",
+    "identifier": "EinharMasterMinionLife2",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "einharmasterminionlife2",
+      "minions have 16-20% increased maximum life"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions deal 10-20% increased Damage",
+    "display": "Minions deal 10-20% increased Damage",
+    "identifier": "EinharMasterMinionDamage1",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "einharmasterminiondamage1",
+      "minions deal 10-20% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "Minions have 13-17% increased Movement Speed",
+    "display": "Minions have 13-17% increased Movement Speed",
+    "identifier": "EinharMasterMinionMovementSpeed1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterminionmovementspeed1",
+      "minions have 13-17% increased movement speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions have 18-22% increased Movement Speed",
+    "display": "Minions have 18-22% increased Movement Speed",
+    "identifier": "EinharMasterMinionMovementSpeed2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterminionmovementspeed2",
+      "minions have 18-22% increased movement speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "Minions deal 37-51% increased Damage",
+    "display": "Minions deal 37-51% increased Damage",
+    "identifier": "EinharMasterMinionDamageOnWeapon2h1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminiondamageonweapon2h1_",
+      "minions deal 37-51% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions deal 52-66% increased Damage",
+    "display": "Minions deal 52-66% increased Damage",
+    "identifier": "EinharMasterMinionDamageOnWeapon2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminiondamageonweapon2h2",
+      "minions deal 52-66% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions deal 67-81% increased Damage",
+    "display": "Minions deal 67-81% increased Damage",
+    "identifier": "EinharMasterMinionDamageOnWeapon2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminiondamageonweapon2h3",
+      "minions deal 67-81% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "Minions deal 25-34% increased Damage",
+    "display": "Minions deal 25-34% increased Damage",
+    "identifier": "EinharMasterMinionDamageOnWeapon1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminiondamageonweapon1h1",
+      "minions deal 25-34% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions deal 35-44% increased Damage",
+    "display": "Minions deal 35-44% increased Damage",
+    "identifier": "EinharMasterMinionDamageOnWeapon1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminiondamageonweapon1h2",
+      "minions deal 35-44% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions deal 45-54% increased Damage",
+    "display": "Minions deal 45-54% increased Damage",
+    "identifier": "EinharMasterMinionDamageOnWeapon1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminiondamageonweapon1h3",
+      "minions deal 45-54% increased damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "52-66% increased Trap Damage",
+    "display": "52-66% increased Trap Damage",
+    "identifier": "EinharMasterTrapDamageOnWeapon2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastertrapdamageonweapon2h1",
+      "52-66% increased trap damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "67-81% increased Trap Damage",
+    "display": "67-81% increased Trap Damage",
+    "identifier": "EinharMasterTrapDamageOnWeapon2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastertrapdamageonweapon2h2",
+      "67-81% increased trap damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "35-44% increased Trap Damage",
+    "display": "35-44% increased Trap Damage",
+    "identifier": "EinharMasterTrapDamageOnWeapon1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastertrapdamageonweapon1h1",
+      "35-44% increased trap damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "45-54% increased Trap Damage",
+    "display": "45-54% increased Trap Damage",
+    "identifier": "EinharMasterTrapDamageOnWeapon1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastertrapdamageonweapon1h2",
+      "45-54% increased trap damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "52-66% increased Mine Damage",
+    "display": "52-66% increased Mine Damage",
+    "identifier": "EinharMasterMineDamageOnWeapon2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminedamageonweapon2h1",
+      "52-66% increased mine damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "67-81% increased Mine Damage",
+    "display": "67-81% increased Mine Damage",
+    "identifier": "EinharMasterMineDamageOnWeapon2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminedamageonweapon2h2",
+      "67-81% increased mine damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "35-44% increased Mine Damage",
+    "display": "35-44% increased Mine Damage",
+    "identifier": "EinharMasterMineDamageOnWeapon1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminedamageonweapon1h1",
+      "35-44% increased mine damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "45-54% increased Mine Damage",
+    "display": "45-54% increased Mine Damage",
+    "identifier": "EinharMasterMineDamageOnWeapon1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminedamageonweapon1h2",
+      "45-54% increased mine damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "17-20% increased Trap Throwing Speed",
+    "display": "17-20% increased Trap Throwing Speed",
+    "identifier": "EinharMasterTrapThrowingSpeed2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastertrapthrowingspeed2h1",
+      "17-20% increased trap throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "21-23% increased Trap Throwing Speed",
+    "display": "21-23% increased Trap Throwing Speed",
+    "identifier": "EinharMasterTrapThrowingSpeed2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmastertrapthrowingspeed2h2_",
+      "21-23% increased trap throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "9-12% increased Trap Throwing Speed",
+    "display": "9-12% increased Trap Throwing Speed",
+    "identifier": "EinharMasterTrapThrowingSpeed1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastertrapthrowingspeed1",
+      "9-12% increased trap throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-15% increased Trap Throwing Speed",
+    "display": "13-15% increased Trap Throwing Speed",
+    "identifier": "EinharMasterTrapThrowingSpeed2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmastertrapthrowingspeed2",
+      "13-15% increased trap throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "17-20% increased Mine Throwing Speed",
+    "display": "17-20% increased Mine Throwing Speed",
+    "identifier": "EinharMasterMineLayingSpeed2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminelayingspeed2h1",
+      "17-20% increased mine throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "21-23% increased Mine Throwing Speed",
+    "display": "21-23% increased Mine Throwing Speed",
+    "identifier": "EinharMasterMineLayingSpeed2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "einharmasterminelayingspeed2h2_",
+      "21-23% increased mine throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "9-12% increased Mine Throwing Speed",
+    "display": "9-12% increased Mine Throwing Speed",
+    "identifier": "EinharMasterMineLayingSpeed1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminelayingspeed1",
+      "9-12% increased mine throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "13-15% increased Mine Throwing Speed",
+    "display": "13-15% increased Mine Throwing Speed",
+    "identifier": "EinharMasterMineLayingSpeed2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "einharmasterminelayingspeed2",
+      "13-15% increased mine throwing speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "3-5% increased Attack Speed",
+    "display": "3-5% increased Attack Speed",
+    "identifier": "EinharMasterAttackSpeedJewelry1",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterattackspeedjewelry1",
+      "3-5% increased attack speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "6-9% increased Cast Speed",
+    "display": "6-9% increased Cast Speed",
+    "identifier": "EinharMasterIncreasedCastSpeedJewelry1",
+    "item_classes": [
+      "Shield",
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterincreasedcastspeedjewelry1",
+      "6-9% increased cast speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "15-20% increased Warcry Speed",
+    "display": "15-20% increased Warcry Speed",
+    "identifier": "EinharMasterWarcrySpeed1",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "einharmasterwarcryspeed1",
+      "15-20% increased warcry speed"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Warcries cannot Exert Travel Skills",
+    "display": "Warcries cannot Exert Travel Skills",
+    "identifier": "CraftedTravelSkillsCannotBeExerted",
+    "item_classes": [
+      "Ring",
+      "Amulet",
+      "Belt"
+    ],
+    "keywords": [
+      "craftedtravelskillscannotbeexerted",
+      "warcries cannot exert travel skills"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when an adjacent Flask is used",
+    "display": "Used when an adjacent Flask is used",
+    "identifier": "FlaskEnchantmentInjectorAdjacentFlasks___",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoradjacentflasks___",
+      "used when an adjacent flask is used"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Reused at the end of this Flask's effect",
+    "display": "Reused at the end of this Flask's effect",
+    "identifier": "FlaskEnchantmentInjectorFlaskEffectEnd",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectorflaskeffectend",
+      "reused at the end of this flask's effect"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when Charges reach full",
+    "display": "Used when Charges reach full",
+    "identifier": "FlaskEnchantmentInjectorOnFullCharges__",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronfullcharges__",
+      "used when charges reach full"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you Use a Guard Skill",
+    "display": "Used when you Use a Guard Skill",
+    "identifier": "FlaskEnchantmentInjectorOnGuardSkillUsed",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronguardskillused",
+      "used when you use a guard skill"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you Use a Travel Skill",
+    "display": "Used when you Use a Travel Skill",
+    "identifier": "FlaskEnchantmentInjectorOnTravelSkillUsed",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectorontravelskillused",
+      "used when you use a travel skill"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you Hit a Rare or Unique Enemy, if not already in effect",
+    "display": "Used when you Hit a Rare or Unique Enemy, if not already in effect",
+    "identifier": "FlaskEnchantmentInjectorOnHittingRareOrUnique_",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronhittingrareorunique_",
+      "used when you hit a rare or unique enemy, if not already in effect"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you become Frozen",
+    "display": "Used when you become Frozen",
+    "identifier": "FlaskEnchantmentInjectorOnAffectedByFreeze__",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronaffectedbyfreeze__",
+      "used when you become frozen"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you become Chilled",
+    "display": "Used when you become Chilled",
+    "identifier": "FlaskEnchantmentInjectorOnAffectedByChill",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronaffectedbychill",
+      "used when you become chilled"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you become Shocked",
+    "display": "Used when you become Shocked",
+    "identifier": "FlaskEnchantmentInjectorOnAffectedByShock_",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronaffectedbyshock_",
+      "used when you become shocked"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you become Ignited",
+    "display": "Used when you become Ignited",
+    "identifier": "FlaskEnchantmentInjectorOnAffectedByIgnite",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronaffectedbyignite",
+      "used when you become ignited"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you start Bleeding",
+    "display": "Used when you start Bleeding",
+    "identifier": "FlaskEnchantmentInjectorOnAffectedByBleed",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronaffectedbybleed",
+      "used when you start bleeding"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you become Poisoned",
+    "display": "Used when you become Poisoned",
+    "identifier": "FlaskEnchantmentInjectorOnAffectedByPoison_",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronaffectedbypoison_",
+      "used when you become poisoned"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you Block",
+    "display": "Used when you Block",
+    "identifier": "FlaskEnchantmentInjectorOnDamageBlocked",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectorondamageblocked",
+      "used when you block"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you take a Savage Hit",
+    "display": "Used when you take a Savage Hit",
+    "identifier": "FlaskEnchantmentInjectorOnTakingSavageHit_",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectorontakingsavagehit_",
+      "used when you take a savage hit"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_enchant_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 5,
+        "currency": "Glassblower's Bauble"
+      },
+      {
+        "amount": 5,
+        "currency": "Instilling Orb"
+      }
+    ],
+    "description": "Used when you use a Life Flask",
+    "display": "Used when you use a Life Flask",
+    "identifier": "FlaskEnchantmentInjectorOnUsingLifeFlask",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "flaskenchantmentinjectoronusinglifeflask",
+      "used when you use a life flask"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "remove_enchantments",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Scouring"
+      }
+    ],
+    "description": "Remove enchantments",
+    "display": "Remove enchantments",
+    "identifier": "Niko, Master of the Depths::Remove enchantments",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Belt",
+      "Amulet",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "remove enchant",
+      "enchant"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Moving while Bleeding doesn't cause you to take extra Damage",
+    "display": "Moving while Bleeding doesn't cause you to take extra Damage",
+    "identifier": "EinharMasterNoExtraDamageFromBleedingWhileMoving1",
+    "item_classes": [
+      "Shield",
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasternoextradamagefrombleedingwhilemoving1",
+      "moving while bleeding doesn't cause you to take extra damage"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+31-36% Chaos Resistance against Damage Over Time",
+    "display": "+31-36% Chaos Resistance against Damage Over Time",
+    "identifier": "EinharMasterChaosResistanceToDamageOverTime1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterchaosresistancetodamageovertime1",
+      "+31-36% chaos resistance against damage over time"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+37-43% Chaos Resistance against Damage Over Time",
+    "display": "+37-43% Chaos Resistance against Damage Over Time",
+    "identifier": "EinharMasterChaosResistanceToDamageOverTime2",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "einharmasterchaosresistancetodamageovertime2",
+      "+37-43% chaos resistance against damage over time"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "41-50% chance to Avoid Bleeding",
+    "display": "41-50% chance to Avoid Bleeding",
+    "identifier": "EinharMasterAvoidBleed1",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasteravoidbleed1",
+      "41-50% chance to avoid bleeding"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "51-60% chance to Avoid Bleeding",
+    "display": "51-60% chance to Avoid Bleeding",
+    "identifier": "EinharMasterAvoidBleed2_",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "einharmasteravoidbleed2_",
+      "51-60% chance to avoid bleeding"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "41-50% reduced Ignite Duration on you",
+    "display": "41-50% reduced Ignite Duration on you",
+    "identifier": "EinharMasterReducedSelfIgniteDuration1",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfigniteduration1",
+      "41-50% reduced ignite duration on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "51-60% reduced Ignite Duration on you",
+    "display": "51-60% reduced Ignite Duration on you",
+    "identifier": "EinharMasterReducedSelfIgniteDuration2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfigniteduration2",
+      "51-60% reduced ignite duration on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "-50--41% increased Effect of Chill on you",
+    "display": "-50--41% increased Effect of Chill on you",
+    "identifier": "EinharMasterReducedSelfChillEffect1",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfchilleffect1",
+      "-50--41% increased effect of chill on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "-60--51% increased Effect of Chill on you",
+    "display": "-60--51% increased Effect of Chill on you",
+    "identifier": "EinharMasterReducedSelfChillEffect2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfchilleffect2",
+      "-60--51% increased effect of chill on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "-50--41% increased Effect of Shock on you",
+    "display": "-50--41% increased Effect of Shock on you",
+    "identifier": "EinharMasterReducedSelfShockEffect1",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfshockeffect1",
+      "-50--41% increased effect of shock on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "-60--51% increased Effect of Shock on you",
+    "display": "-60--51% increased Effect of Shock on you",
+    "identifier": "EinharMasterReducedSelfShockEffect2_",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfshockeffect2_",
+      "-60--51% increased effect of shock on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "-20--16% increased Effect of Curses on you",
+    "display": "-20--16% increased Effect of Curses on you",
+    "identifier": "EinharMasterReducedSelfCurseEffect1",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfcurseeffect1",
+      "-20--16% increased effect of curses on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "-25--21% increased Effect of Curses on you",
+    "display": "-25--21% increased Effect of Curses on you",
+    "identifier": "EinharMasterReducedSelfCurseEffect2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "einharmasterreducedselfcurseeffect2",
+      "-25--21% increased effect of curses on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "-15--11% increased Effect of Freeze on you",
+    "display": "-15--11% increased Effect of Freeze on you",
+    "identifier": "EinharMasterReducedSelfFreezeEffect1",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "einharmasterreducedselffreezeeffect1",
+      "-15--11% increased effect of freeze on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "-20--16% increased Effect of Freeze on you",
+    "display": "-20--16% increased Effect of Freeze on you",
+    "identifier": "EinharMasterReducedSelfFreezeEffect2_",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "einharmasterreducedselffreezeeffect2_",
+      "-20--16% increased effect of freeze on you"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 9-11 to 16-21 Fire Damage to Attacks",
+    "display": "Adds 9-11 to 16-21 Fire Damage to Attacks",
+    "identifier": "EinharMasterAddedFireDamageQuiver1___",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedfiredamagequiver1___",
+      "adds 9-11 to 16-21 fire damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 19-23 to 37-42 Fire Damage to Attacks",
+    "display": "Adds 19-23 to 37-42 Fire Damage to Attacks",
+    "identifier": "EinharMasterAddedFireDamageQuiver2",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedfiredamagequiver2",
+      "adds 19-23 to 37-42 fire damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 9-11 to 16-21 Cold Damage to Attacks",
+    "display": "Adds 9-11 to 16-21 Cold Damage to Attacks",
+    "identifier": "EinharMasterAddedColdDamageQuiver1__",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedcolddamagequiver1__",
+      "adds 9-11 to 16-21 cold damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 19-23 to 37-42 Cold Damage to Attacks",
+    "display": "Adds 19-23 to 37-42 Cold Damage to Attacks",
+    "identifier": "EinharMasterAddedColdDamageQuiver2",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedcolddamagequiver2",
+      "adds 19-23 to 37-42 cold damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 1-4 to 32-36 Lightning Damage to Attacks",
+    "display": "Adds 1-4 to 32-36 Lightning Damage to Attacks",
+    "identifier": "EinharMasterAddedLightningDamageQuiver1_",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedlightningdamagequiver1_",
+      "adds 1-4 to 32-36 lightning damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 3-6 to 52-70 Lightning Damage to Attacks",
+    "display": "Adds 3-6 to 52-70 Lightning Damage to Attacks",
+    "identifier": "EinharMasterAddedLightningDamageQuiver2_",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "einharmasteraddedlightningdamagequiver2_",
+      "adds 3-6 to 52-70 lightning damage to attacks"
+    ],
+    "master": "Niko, Master of the Depths"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "No Physical Damage; 13-15% chance to Impale Enemies on Hit with Attacks",
+    "display": "No Physical Damage; 13-15% chance to Impale Enemies on Hit with Attacks",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndImpaleCrafted1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandimpalecrafted1",
+      "no physical damage",
+      "13-15% chance to impale enemies on hit with attacks"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 16-17% chance to Impale Enemies on Hit with Attacks",
+    "display": "No Physical Damage; 16-17% chance to Impale Enemies on Hit with Attacks",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndImpaleCrafted2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandimpalecrafted2",
+      "no physical damage",
+      "16-17% chance to impale enemies on hit with attacks"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 18-20% chance to Impale Enemies on Hit with Attacks",
+    "display": "No Physical Damage; 18-20% chance to Impale Enemies on Hit with Attacks",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndImpaleCrafted3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandimpalecrafted3",
+      "no physical damage",
+      "18-20% chance to impale enemies on hit with attacks"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "No Physical Damage; 13-15% chance to cause Bleeding on Hit",
+    "display": "No Physical Damage; 13-15% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndBleedChanceCrafted1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandbleedchancecrafted1",
+      "no physical damage",
+      "13-15% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 16-17% chance to cause Bleeding on Hit",
+    "display": "No Physical Damage; 16-17% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndBleedChanceCrafted2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandbleedchancecrafted2",
+      "no physical damage",
+      "16-17% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 18-20% chance to cause Bleeding on Hit",
+    "display": "No Physical Damage; 18-20% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndBleedChanceCrafted3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandbleedchancecrafted3",
+      "no physical damage",
+      "18-20% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "No Physical Damage; 13-15% chance to Blind Enemies on hit",
+    "display": "No Physical Damage; 13-15% chance to Blind Enemies on hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndBlindChanceCrafted1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandblindchancecrafted1_",
+      "no physical damage",
+      "13-15% chance to blind enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 16-17% chance to Blind Enemies on hit",
+    "display": "No Physical Damage; 16-17% chance to Blind Enemies on hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndBlindChanceCrafted2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandblindchancecrafted2",
+      "no physical damage",
+      "16-17% chance to blind enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 18-20% chance to Blind Enemies on hit",
+    "display": "No Physical Damage; 18-20% chance to Blind Enemies on hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndBlindChanceCrafted3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandblindchancecrafted3",
+      "no physical damage",
+      "18-20% chance to blind enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "No Physical Damage; 13-15% chance to Poison on Hit",
+    "display": "No Physical Damage; 13-15% chance to Poison on Hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndPoisonChanceCrafted1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandpoisonchancecrafted1",
+      "no physical damage",
+      "13-15% chance to poison on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 16-17% chance to Poison on Hit",
+    "display": "No Physical Damage; 16-17% chance to Poison on Hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndPoisonChanceCrafted2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandpoisonchancecrafted2_",
+      "no physical damage",
+      "16-17% chance to poison on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "No Physical Damage; 18-20% chance to Poison on Hit",
+    "display": "No Physical Damage; 18-20% chance to Poison on Hit",
+    "identifier": "JunMaster2LocalIncreasedPhysicalDamageAndPoisonChanceCrafted3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localincreasedphysicaldamageandpoisonchancecrafted3",
+      "no physical damage",
+      "18-20% chance to poison on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "60-64% increased Fire Damage; 21-24% chance to Ignite",
+    "display": "60-64% increased Fire Damage; 21-24% chance to Ignite",
+    "identifier": "JunMaster2FireDamageAndChanceToIgnite2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2firedamageandchancetoignite2h1",
+      "60-64% increased fire damage",
+      "21-24% chance to ignite"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "65-72% increased Fire Damage; 25-28% chance to Ignite",
+    "display": "65-72% increased Fire Damage; 25-28% chance to Ignite",
+    "identifier": "JunMaster2FireDamageAndChanceToIgnite2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2firedamageandchancetoignite2h2",
+      "65-72% increased fire damage",
+      "25-28% chance to ignite"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "73-80% increased Fire Damage; 29-34% chance to Ignite",
+    "display": "73-80% increased Fire Damage; 29-34% chance to Ignite",
+    "identifier": "JunMaster2FireDamageAndChanceToIgnite2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2firedamageandchancetoignite2h3",
+      "73-80% increased fire damage",
+      "29-34% chance to ignite"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "36-41% increased Fire Damage; 13-15% chance to Ignite",
+    "display": "36-41% increased Fire Damage; 13-15% chance to Ignite",
+    "identifier": "JunMaster2FireDamageAndChanceToIgnite1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2firedamageandchancetoignite1h1",
+      "36-41% increased fire damage",
+      "13-15% chance to ignite"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "42-50% increased Fire Damage; 16-17% chance to Ignite",
+    "display": "42-50% increased Fire Damage; 16-17% chance to Ignite",
+    "identifier": "JunMaster2FireDamageAndChanceToIgnite1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2firedamageandchancetoignite1h2",
+      "42-50% increased fire damage",
+      "16-17% chance to ignite"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "51-60% increased Fire Damage; 18-20% chance to Ignite",
+    "display": "51-60% increased Fire Damage; 18-20% chance to Ignite",
+    "identifier": "JunMaster2FireDamageAndChanceToIgnite1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2firedamageandchancetoignite1h3",
+      "51-60% increased fire damage",
+      "18-20% chance to ignite"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "60-64% increased Cold Damage; Always Freezes Enemies on Hit",
+    "display": "60-64% increased Cold Damage; Always Freezes Enemies on Hit",
+    "identifier": "JunMaster2ColdDamageAndBaseChanceToFreeze2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2colddamageandbasechancetofreeze2h1",
+      "60-64% increased cold damage",
+      "always freezes enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "65-72% increased Cold Damage; Always Freezes Enemies on Hit",
+    "display": "65-72% increased Cold Damage; Always Freezes Enemies on Hit",
+    "identifier": "JunMaster2ColdDamageAndBaseChanceToFreeze2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2colddamageandbasechancetofreeze2h2",
+      "65-72% increased cold damage",
+      "always freezes enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "73-80% increased Cold Damage; Always Freezes Enemies on Hit",
+    "display": "73-80% increased Cold Damage; Always Freezes Enemies on Hit",
+    "identifier": "JunMaster2ColdDamageAndBaseChanceToFreeze2h3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2colddamageandbasechancetofreeze2h3_",
+      "73-80% increased cold damage",
+      "always freezes enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "36-41% increased Cold Damage; Always Freezes Enemies on Hit",
+    "display": "36-41% increased Cold Damage; Always Freezes Enemies on Hit",
+    "identifier": "JunMaster2ColdDamageAndBaseChanceToFreeze1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2colddamageandbasechancetofreeze1h1",
+      "36-41% increased cold damage",
+      "always freezes enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "42-50% increased Cold Damage; Always Freezes Enemies on Hit",
+    "display": "42-50% increased Cold Damage; Always Freezes Enemies on Hit",
+    "identifier": "JunMaster2ColdDamageAndBaseChanceToFreeze1h2__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2colddamageandbasechancetofreeze1h2__",
+      "42-50% increased cold damage",
+      "always freezes enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "51-60% increased Cold Damage; Always Freezes Enemies on Hit",
+    "display": "51-60% increased Cold Damage; Always Freezes Enemies on Hit",
+    "identifier": "JunMaster2ColdDamageAndBaseChanceToFreeze1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2colddamageandbasechancetofreeze1h3",
+      "51-60% increased cold damage",
+      "always freezes enemies on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "60-64% increased Lightning Damage; 21-24% chance to Shock",
+    "display": "60-64% increased Lightning Damage; 21-24% chance to Shock",
+    "identifier": "JunMaster2LightningDamageAndChanceToShock2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2lightningdamageandchancetoshock2h1",
+      "60-64% increased lightning damage",
+      "21-24% chance to shock"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "65-72% increased Lightning Damage; 25-28% chance to Shock",
+    "display": "65-72% increased Lightning Damage; 25-28% chance to Shock",
+    "identifier": "JunMaster2LightningDamageAndChanceToShock2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2lightningdamageandchancetoshock2h2",
+      "65-72% increased lightning damage",
+      "25-28% chance to shock"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "73-80% increased Lightning Damage; 29-34% chance to Shock",
+    "display": "73-80% increased Lightning Damage; 29-34% chance to Shock",
+    "identifier": "JunMaster2LightningDamageAndChanceToShock2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2lightningdamageandchancetoshock2h3",
+      "73-80% increased lightning damage",
+      "29-34% chance to shock"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "36-41% increased Lightning Damage; 13-15% chance to Shock",
+    "display": "36-41% increased Lightning Damage; 13-15% chance to Shock",
+    "identifier": "JunMaster2LightningDamageAndChanceToShock1h1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2lightningdamageandchancetoshock1h1_",
+      "36-41% increased lightning damage",
+      "13-15% chance to shock"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "42-50% increased Lightning Damage; 16-17% chance to Shock",
+    "display": "42-50% increased Lightning Damage; 16-17% chance to Shock",
+    "identifier": "JunMaster2LightningDamageAndChanceToShock1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2lightningdamageandchancetoshock1h2",
+      "42-50% increased lightning damage",
+      "16-17% chance to shock"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "51-60% increased Lightning Damage; 18-20% chance to Shock",
+    "display": "51-60% increased Lightning Damage; 18-20% chance to Shock",
+    "identifier": "JunMaster2LightningDamageAndChanceToShock1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2lightningdamageandchancetoshock1h3",
+      "51-60% increased lightning damage",
+      "18-20% chance to shock"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "53-60% increased Chaos Damage; Chaos Skills have 15-17% increased Skill Effect Duration",
+    "display": "53-60% increased Chaos Damage; Chaos Skills have 15-17% increased Skill Effect Duration",
+    "identifier": "JunMaster2ChaosDamageAndChaosSkillDuration2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageandchaosskillduration2h1",
+      "53-60% increased chaos damage",
+      "chaos skills have 15-17% increased skill effect duration"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "61-68% increased Chaos Damage; Chaos Skills have 18-20% increased Skill Effect Duration",
+    "display": "61-68% increased Chaos Damage; Chaos Skills have 18-20% increased Skill Effect Duration",
+    "identifier": "JunMaster2ChaosDamageAndChaosSkillDuration2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageandchaosskillduration2h2",
+      "61-68% increased chaos damage",
+      "chaos skills have 18-20% increased skill effect duration"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "69-75% increased Chaos Damage; Chaos Skills have 21-23% increased Skill Effect Duration",
+    "display": "69-75% increased Chaos Damage; Chaos Skills have 21-23% increased Skill Effect Duration",
+    "identifier": "JunMaster2ChaosDamageAndChaosSkillDuration2h3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageandchaosskillduration2h3_",
+      "69-75% increased chaos damage",
+      "chaos skills have 21-23% increased skill effect duration"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "35-39% increased Chaos Damage; Chaos Skills have 7-8% increased Skill Effect Duration",
+    "display": "35-39% increased Chaos Damage; Chaos Skills have 7-8% increased Skill Effect Duration",
+    "identifier": "JunMaster2ChaosDamageAndChaosSkillDuration1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageandchaosskillduration1h1",
+      "35-39% increased chaos damage",
+      "chaos skills have 7-8% increased skill effect duration"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "40-45% increased Chaos Damage; Chaos Skills have 9-10% increased Skill Effect Duration",
+    "display": "40-45% increased Chaos Damage; Chaos Skills have 9-10% increased Skill Effect Duration",
+    "identifier": "JunMaster2ChaosDamageAndChaosSkillDuration1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageandchaosskillduration1h2",
+      "40-45% increased chaos damage",
+      "chaos skills have 9-10% increased skill effect duration"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "46-50% increased Chaos Damage; Chaos Skills have 11-12% increased Skill Effect Duration",
+    "display": "46-50% increased Chaos Damage; Chaos Skills have 11-12% increased Skill Effect Duration",
+    "identifier": "JunMaster2ChaosDamageAndChaosSkillDuration1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageandchaosskillduration1h3",
+      "46-50% increased chaos damage",
+      "chaos skills have 11-12% increased skill effect duration"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "60-64% increased Spell Damage; 16-20% increased Mana Regeneration Rate",
+    "display": "60-64% increased Spell Damage; 16-20% increased Mana Regeneration Rate",
+    "identifier": "JunMaster2SpellDamageAndManaRegenerationRate2h1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandmanaregenerationrate2h1_",
+      "60-64% increased spell damage",
+      "16-20% increased mana regeneration rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "65-72% increased Spell Damage; 21-25% increased Mana Regeneration Rate",
+    "display": "65-72% increased Spell Damage; 21-25% increased Mana Regeneration Rate",
+    "identifier": "JunMaster2SpellDamageAndManaRegenerationRate2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandmanaregenerationrate2h2_",
+      "65-72% increased spell damage",
+      "21-25% increased mana regeneration rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "73-80% increased Spell Damage; 26-30% increased Mana Regeneration Rate",
+    "display": "73-80% increased Spell Damage; 26-30% increased Mana Regeneration Rate",
+    "identifier": "JunMaster2SpellDamageAndManaRegenerationRate2h3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandmanaregenerationrate2h3_",
+      "73-80% increased spell damage",
+      "26-30% increased mana regeneration rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "36-41% increased Spell Damage; 7-9% increased Mana Regeneration Rate",
+    "display": "36-41% increased Spell Damage; 7-9% increased Mana Regeneration Rate",
+    "identifier": "JunMaster2SpellDamageAndManaRegenerationRate1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandmanaregenerationrate1h1",
+      "36-41% increased spell damage",
+      "7-9% increased mana regeneration rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "42-50% increased Spell Damage; 10-12% increased Mana Regeneration Rate",
+    "display": "42-50% increased Spell Damage; 10-12% increased Mana Regeneration Rate",
+    "identifier": "JunMaster2SpellDamageAndManaRegenerationRate1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandmanaregenerationrate1h2",
+      "42-50% increased spell damage",
+      "10-12% increased mana regeneration rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "51-60% increased Spell Damage; 13-15% increased Mana Regeneration Rate",
+    "display": "51-60% increased Spell Damage; 13-15% increased Mana Regeneration Rate",
+    "identifier": "JunMaster2SpellDamageAndManaRegenerationRate1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandmanaregenerationrate1h3",
+      "51-60% increased spell damage",
+      "13-15% increased mana regeneration rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "53-58% increased Spell Damage; Gain 3-4% of Non-Chaos Damage as extra Chaos Damage",
+    "display": "53-58% increased Spell Damage; Gain 3-4% of Non-Chaos Damage as extra Chaos Damage",
+    "identifier": "JunMaster2SpellDamageAndNonChaosDamageToAddAsChaosDamage2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandnonchaosdamagetoaddaschaosdamage2h1",
+      "53-58% increased spell damage",
+      "gain 3-4% of non-chaos damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "59-66% increased Spell Damage; Gain 5-6% of Non-Chaos Damage as extra Chaos Damage",
+    "display": "59-66% increased Spell Damage; Gain 5-6% of Non-Chaos Damage as extra Chaos Damage",
+    "identifier": "JunMaster2SpellDamageAndNonChaosDamageToAddAsChaosDamage2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandnonchaosdamagetoaddaschaosdamage2h2",
+      "59-66% increased spell damage",
+      "gain 5-6% of non-chaos damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "67-75% increased Spell Damage; Gain 7-8% of Non-Chaos Damage as extra Chaos Damage",
+    "display": "67-75% increased Spell Damage; Gain 7-8% of Non-Chaos Damage as extra Chaos Damage",
+    "identifier": "JunMaster2SpellDamageAndNonChaosDamageToAddAsChaosDamage2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandnonchaosdamagetoaddaschaosdamage2h3",
+      "67-75% increased spell damage",
+      "gain 7-8% of non-chaos damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "38-40% increased Spell Damage; Gain 2% of Non-Chaos Damage as extra Chaos Damage",
+    "display": "38-40% increased Spell Damage; Gain 2% of Non-Chaos Damage as extra Chaos Damage",
+    "identifier": "JunMaster2SpellDamageAndNonChaosDamageToAddAsChaosDamage1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandnonchaosdamagetoaddaschaosdamage1h1",
+      "38-40% increased spell damage",
+      "gain 2% of non-chaos damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "41-45% increased Spell Damage; Gain 3% of Non-Chaos Damage as extra Chaos Damage",
+    "display": "41-45% increased Spell Damage; Gain 3% of Non-Chaos Damage as extra Chaos Damage",
+    "identifier": "JunMaster2SpellDamageAndNonChaosDamageToAddAsChaosDamage1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandnonchaosdamagetoaddaschaosdamage1h2",
+      "41-45% increased spell damage",
+      "gain 3% of non-chaos damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "46-50% increased Spell Damage; Gain 4% of Non-Chaos Damage as extra Chaos Damage",
+    "display": "46-50% increased Spell Damage; Gain 4% of Non-Chaos Damage as extra Chaos Damage",
+    "identifier": "JunMaster2SpellDamageAndNonChaosDamageToAddAsChaosDamage1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2spelldamageandnonchaosdamagetoaddaschaosdamage1h3",
+      "46-50% increased spell damage",
+      "gain 4% of non-chaos damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Minions deal 26-32% increased Damage; Minions have 26-32% increased maximum Life",
+    "display": "Minions deal 26-32% increased Damage; Minions have 26-32% increased maximum Life",
+    "identifier": "JunMaster2MinionDamageAndMinionMaximumLife2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2miniondamageandminionmaximumlife2h1",
+      "minions deal 26-32% increased damage",
+      "minions have 26-32% increased maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions deal 33-38% increased Damage; Minions have 33-38% increased maximum Life",
+    "display": "Minions deal 33-38% increased Damage; Minions have 33-38% increased maximum Life",
+    "identifier": "JunMaster2MinionDamageAndMinionMaximumLife2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2miniondamageandminionmaximumlife2h2_",
+      "minions deal 33-38% increased damage",
+      "minions have 33-38% increased maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions deal 39-45% increased Damage; Minions have 39-45% increased maximum Life",
+    "display": "Minions deal 39-45% increased Damage; Minions have 39-45% increased maximum Life",
+    "identifier": "JunMaster2MinionDamageAndMinionMaximumLife2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2miniondamageandminionmaximumlife2h3",
+      "minions deal 39-45% increased damage",
+      "minions have 39-45% increased maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Minions deal 16-19% increased Damage; Minions have 16-19% increased maximum Life",
+    "display": "Minions deal 16-19% increased Damage; Minions have 16-19% increased maximum Life",
+    "identifier": "JunMaster2MinionDamageAndMinionMaximumLife1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2miniondamageandminionmaximumlife1h1",
+      "minions deal 16-19% increased damage",
+      "minions have 16-19% increased maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions deal 20-24% increased Damage; Minions have 20-24% increased maximum Life",
+    "display": "Minions deal 20-24% increased Damage; Minions have 20-24% increased maximum Life",
+    "identifier": "JunMaster2MinionDamageAndMinionMaximumLife1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2miniondamageandminionmaximumlife1h2",
+      "minions deal 20-24% increased damage",
+      "minions have 20-24% increased maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions deal 25-28% increased Damage; Minions have 25-28% increased maximum Life",
+    "display": "Minions deal 25-28% increased Damage; Minions have 25-28% increased maximum Life",
+    "identifier": "JunMaster2MinionDamageAndMinionMaximumLife1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2miniondamageandminionmaximumlife1h3",
+      "minions deal 25-28% increased damage",
+      "minions have 25-28% increased maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Minions have 19-21% increased Attack Speed; Minions have 19-21% increased Cast Speed",
+    "display": "Minions have 19-21% increased Attack Speed; Minions have 19-21% increased Cast Speed",
+    "identifier": "JunMaster2MinionAttackAndCastSpeedOnWeapon2h1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2minionattackandcastspeedonweapon2h1_",
+      "minions have 19-21% increased attack speed",
+      "minions have 19-21% increased cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions have 22-24% increased Attack Speed; Minions have 22-24% increased Cast Speed",
+    "display": "Minions have 22-24% increased Attack Speed; Minions have 22-24% increased Cast Speed",
+    "identifier": "JunMaster2MinionAttackAndCastSpeedOnWeapon2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2minionattackandcastspeedonweapon2h2",
+      "minions have 22-24% increased attack speed",
+      "minions have 22-24% increased cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions have 25-28% increased Attack Speed; Minions have 25-28% increased Cast Speed",
+    "display": "Minions have 25-28% increased Attack Speed; Minions have 25-28% increased Cast Speed",
+    "identifier": "JunMaster2MinionAttackAndCastSpeedOnWeapon2h3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2minionattackandcastspeedonweapon2h3_",
+      "minions have 25-28% increased attack speed",
+      "minions have 25-28% increased cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Minions have 10-11% increased Attack Speed; Minions have 10-11% increased Cast Speed",
+    "display": "Minions have 10-11% increased Attack Speed; Minions have 10-11% increased Cast Speed",
+    "identifier": "JunMaster2MinionAttackAndCastSpeedOnWeapon1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2minionattackandcastspeedonweapon1h1",
+      "minions have 10-11% increased attack speed",
+      "minions have 10-11% increased cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Minions have 12-13% increased Attack Speed; Minions have 12-13% increased Cast Speed",
+    "display": "Minions have 12-13% increased Attack Speed; Minions have 12-13% increased Cast Speed",
+    "identifier": "JunMaster2MinionAttackAndCastSpeedOnWeapon1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2minionattackandcastspeedonweapon1h2",
+      "minions have 12-13% increased attack speed",
+      "minions have 12-13% increased cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions have 14-15% increased Attack Speed; Minions have 14-15% increased Cast Speed",
+    "display": "Minions have 14-15% increased Attack Speed; Minions have 14-15% increased Cast Speed",
+    "identifier": "JunMaster2MinionAttackAndCastSpeedOnWeapon1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2minionattackandcastspeedonweapon1h3",
+      "minions have 14-15% increased attack speed",
+      "minions have 14-15% increased cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+25-27% to Chaos Damage over Time Multiplier",
+    "display": "+25-27% to Chaos Damage over Time Multiplier",
+    "identifier": "JunMaster2ChaosDamageOverTimeMultiplierTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageovertimemultipliertwohand1",
+      "+25-27% to chaos damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+28-30% to Chaos Damage over Time Multiplier",
+    "display": "+28-30% to Chaos Damage over Time Multiplier",
+    "identifier": "JunMaster2ChaosDamageOverTimeMultiplierTwoHand2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageovertimemultipliertwohand2_",
+      "+28-30% to chaos damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+31-35% to Chaos Damage over Time Multiplier",
+    "display": "+31-35% to Chaos Damage over Time Multiplier",
+    "identifier": "JunMaster2ChaosDamageOverTimeMultiplierTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageovertimemultipliertwohand3",
+      "+31-35% to chaos damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+14-15% to Chaos Damage over Time Multiplier",
+    "display": "+14-15% to Chaos Damage over Time Multiplier",
+    "identifier": "JunMaster2ChaosDamageOverTimeMultiplier1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageovertimemultiplier1_",
+      "+14-15% to chaos damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-17% to Chaos Damage over Time Multiplier",
+    "display": "+16-17% to Chaos Damage over Time Multiplier",
+    "identifier": "JunMaster2ChaosDamageOverTimeMultiplier2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageovertimemultiplier2",
+      "+16-17% to chaos damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+18-20% to Chaos Damage over Time Multiplier",
+    "display": "+18-20% to Chaos Damage over Time Multiplier",
+    "identifier": "JunMaster2ChaosDamageOverTimeMultiplier3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2chaosdamageovertimemultiplier3",
+      "+18-20% to chaos damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+25-27% to Physical Damage over Time Multiplier",
+    "display": "+25-27% to Physical Damage over Time Multiplier",
+    "identifier": "JunMaster2PhysicalDamageOverTimeMultiplierTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageovertimemultipliertwohand1",
+      "+25-27% to physical damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+28-30% to Physical Damage over Time Multiplier",
+    "display": "+28-30% to Physical Damage over Time Multiplier",
+    "identifier": "JunMaster2PhysicalDamageOverTimeMultiplierTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageovertimemultipliertwohand2",
+      "+28-30% to physical damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+31-35% to Physical Damage over Time Multiplier",
+    "display": "+31-35% to Physical Damage over Time Multiplier",
+    "identifier": "JunMaster2PhysicalDamageOverTimeMultiplierTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageovertimemultipliertwohand3",
+      "+31-35% to physical damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+14-15% to Physical Damage over Time Multiplier",
+    "display": "+14-15% to Physical Damage over Time Multiplier",
+    "identifier": "JunMaster2PhysicalDamageOverTimeMultiplier1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageovertimemultiplier1_",
+      "+14-15% to physical damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-17% to Physical Damage over Time Multiplier",
+    "display": "+16-17% to Physical Damage over Time Multiplier",
+    "identifier": "JunMaster2PhysicalDamageOverTimeMultiplier2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageovertimemultiplier2",
+      "+16-17% to physical damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+18-20% to Physical Damage over Time Multiplier",
+    "display": "+18-20% to Physical Damage over Time Multiplier",
+    "identifier": "JunMaster2PhysicalDamageOverTimeMultiplier3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageovertimemultiplier3",
+      "+18-20% to physical damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+25-27% to Cold Damage over Time Multiplier",
+    "display": "+25-27% to Cold Damage over Time Multiplier",
+    "identifier": "JunMaster2ColdDamageOverTimeMultiplierTwoHand1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2colddamageovertimemultipliertwohand1",
+      "+25-27% to cold damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+28-30% to Cold Damage over Time Multiplier",
+    "display": "+28-30% to Cold Damage over Time Multiplier",
+    "identifier": "JunMaster2ColdDamageOverTimeMultiplierTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2colddamageovertimemultipliertwohand2",
+      "+28-30% to cold damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+31-35% to Cold Damage over Time Multiplier",
+    "display": "+31-35% to Cold Damage over Time Multiplier",
+    "identifier": "JunMaster2ColdDamageOverTimeMultiplierTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2colddamageovertimemultipliertwohand3",
+      "+31-35% to cold damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+14-15% to Cold Damage over Time Multiplier",
+    "display": "+14-15% to Cold Damage over Time Multiplier",
+    "identifier": "JunMaster2ColdDamageOverTimeMultiplier1__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2colddamageovertimemultiplier1__",
+      "+14-15% to cold damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-17% to Cold Damage over Time Multiplier",
+    "display": "+16-17% to Cold Damage over Time Multiplier",
+    "identifier": "JunMaster2ColdDamageOverTimeMultiplier2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2colddamageovertimemultiplier2",
+      "+16-17% to cold damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+18-20% to Cold Damage over Time Multiplier",
+    "display": "+18-20% to Cold Damage over Time Multiplier",
+    "identifier": "JunMaster2ColdDamageOverTimeMultiplier3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2colddamageovertimemultiplier3_",
+      "+18-20% to cold damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+25-27% to Fire Damage over Time Multiplier",
+    "display": "+25-27% to Fire Damage over Time Multiplier",
+    "identifier": "JunMaster2FireDamageOverTimeMultiplierTwoHand1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2firedamageovertimemultipliertwohand1_",
+      "+25-27% to fire damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+28-30% to Fire Damage over Time Multiplier",
+    "display": "+28-30% to Fire Damage over Time Multiplier",
+    "identifier": "JunMaster2FireDamageOverTimeMultiplierTwoHand2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2firedamageovertimemultipliertwohand2",
+      "+28-30% to fire damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+31-35% to Fire Damage over Time Multiplier",
+    "display": "+31-35% to Fire Damage over Time Multiplier",
+    "identifier": "JunMaster2FireDamageOverTimeMultiplierTwoHand3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2firedamageovertimemultipliertwohand3",
+      "+31-35% to fire damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+14-15% to Fire Damage over Time Multiplier",
+    "display": "+14-15% to Fire Damage over Time Multiplier",
+    "identifier": "JunMaster2FireDamageOverTimeMultiplier1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2firedamageovertimemultiplier1_",
+      "+14-15% to fire damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-17% to Fire Damage over Time Multiplier",
+    "display": "+16-17% to Fire Damage over Time Multiplier",
+    "identifier": "JunMaster2FireDamageOverTimeMultiplier2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2firedamageovertimemultiplier2",
+      "+16-17% to fire damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+18-20% to Fire Damage over Time Multiplier",
+    "display": "+18-20% to Fire Damage over Time Multiplier",
+    "identifier": "JunMaster2FireDamageOverTimeMultiplier3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2firedamageovertimemultiplier3_",
+      "+18-20% to fire damage over time multiplier"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Attacks with this Weapon Penetrate 6-7% Elemental Resistances",
+    "display": "Attacks with this Weapon Penetrate 6-7% Elemental Resistances",
+    "identifier": "JunMaster2ElementalPenetrationWithAttacks1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2elementalpenetrationwithattacks1",
+      "attacks with this weapon penetrate 6-7% elemental resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Attacks with this Weapon Penetrate 8-10% Elemental Resistances",
+    "display": "Attacks with this Weapon Penetrate 8-10% Elemental Resistances",
+    "identifier": "JunMaster2ElementalPenetrationWithAttacks2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2elementalpenetrationwithattacks2",
+      "attacks with this weapon penetrate 8-10% elemental resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "Attacks with this Weapon Penetrate 11-13% Elemental Resistances",
+    "display": "Attacks with this Weapon Penetrate 11-13% Elemental Resistances",
+    "identifier": "JunMaster2ElementalPenetrationWithAttacks3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2elementalpenetrationwithattacks3",
+      "attacks with this weapon penetrate 11-13% elemental resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Attacks with this Weapon Penetrate 6-7% Chaos Resistance",
+    "display": "Attacks with this Weapon Penetrate 6-7% Chaos Resistance",
+    "identifier": "JunMaster2ChaosPenetrationWithAttacks1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2chaospenetrationwithattacks1",
+      "attacks with this weapon penetrate 6-7% chaos resistance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Attacks with this Weapon Penetrate 8-10% Chaos Resistance",
+    "display": "Attacks with this Weapon Penetrate 8-10% Chaos Resistance",
+    "identifier": "JunMaster2ChaosPenetrationWithAttacks2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2chaospenetrationwithattacks2",
+      "attacks with this weapon penetrate 8-10% chaos resistance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Attacks with this Weapon Penetrate 11-13% Chaos Resistance",
+    "display": "Attacks with this Weapon Penetrate 11-13% Chaos Resistance",
+    "identifier": "JunMaster2ChaosPenetrationWithAttacks3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2chaospenetrationwithattacks3_",
+      "attacks with this weapon penetrate 11-13% chaos resistance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "6-7% chance to deal Double Damage",
+    "display": "6-7% chance to deal Double Damage",
+    "identifier": "JunMaster2DoubleDamageChance2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2doubledamagechance2h1",
+      "6-7% chance to deal double damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "8-10% chance to deal Double Damage",
+    "display": "8-10% chance to deal Double Damage",
+    "identifier": "JunMaster2DoubleDamageChance2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2doubledamagechance2h2",
+      "8-10% chance to deal double damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "3% chance to deal Double Damage",
+    "display": "3% chance to deal Double Damage",
+    "identifier": "JunMaster2DoubleDamageChance1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2doubledamagechance1h1",
+      "3% chance to deal double damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "4-5% chance to deal Double Damage",
+    "display": "4-5% chance to deal Double Damage",
+    "identifier": "JunMaster2DoubleDamageChance1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2doubledamagechance1h2",
+      "4-5% chance to deal double damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour and Evasion; +8-9 to maximum Life",
+    "display": "12-14% increased Armour and Evasion; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLife1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlife1",
+      "12-14% increased armour and evasion",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour and Evasion; +10-11 to maximum Life",
+    "display": "15-17% increased Armour and Evasion; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLife2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlife2",
+      "15-17% increased armour and evasion",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour and Evasion; +12-14 to maximum Life",
+    "display": "18-21% increased Armour and Evasion; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLife3",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlife3",
+      "18-21% increased armour and evasion",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour and Energy Shield; +8-9 to maximum Life",
+    "display": "12-14% increased Armour and Energy Shield; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLife1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlife1",
+      "12-14% increased armour and energy shield",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour and Energy Shield; +10-11 to maximum Life",
+    "display": "15-17% increased Armour and Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLife2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlife2",
+      "15-17% increased armour and energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour and Energy Shield; +12-14 to maximum Life",
+    "display": "18-21% increased Armour and Energy Shield; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLife3__",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlife3__",
+      "18-21% increased armour and energy shield",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Evasion and Energy Shield; +8-9 to maximum Life",
+    "display": "12-14% increased Evasion and Energy Shield; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLife1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlife1",
+      "12-14% increased evasion and energy shield",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Evasion and Energy Shield; +10-11 to maximum Life",
+    "display": "15-17% increased Evasion and Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLife2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlife2",
+      "15-17% increased evasion and energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Evasion and Energy Shield; +12-14 to maximum Life",
+    "display": "18-21% increased Evasion and Energy Shield; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLife3",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlife3",
+      "18-21% increased evasion and energy shield",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour; +8-9 to maximum Life",
+    "display": "12-14% increased Armour; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLife1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlife1",
+      "12-14% increased armour",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour; +10-11 to maximum Life",
+    "display": "15-17% increased Armour; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLife2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlife2",
+      "15-17% increased armour",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour; +12-14 to maximum Life",
+    "display": "18-21% increased Armour; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLife3",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlife3",
+      "18-21% increased armour",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Evasion Rating; +8-9 to maximum Life",
+    "display": "12-14% increased Evasion Rating; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLife1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlife1",
+      "12-14% increased evasion rating",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Evasion Rating; +10-11 to maximum Life",
+    "display": "15-17% increased Evasion Rating; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLife2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlife2",
+      "15-17% increased evasion rating",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Evasion Rating; +12-14 to maximum Life",
+    "display": "18-21% increased Evasion Rating; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLife3",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlife3",
+      "18-21% increased evasion rating",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Energy Shield; +8-9 to maximum Life",
+    "display": "12-14% increased Energy Shield; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLife1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlife1",
+      "12-14% increased energy shield",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Energy Shield; +10-11 to maximum Life",
+    "display": "15-17% increased Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLife2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlife2",
+      "15-17% increased energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Energy Shield; +12-14 to maximum Life",
+    "display": "18-21% increased Energy Shield; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLife3",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlife3",
+      "18-21% increased energy shield",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour, Evasion and Energy Shield; +8-9 to maximum Life",
+    "display": "12-14% increased Armour, Evasion and Energy Shield; +8-9 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLife1_",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlife1_",
+      "12-14% increased armour, evasion and energy shield",
+      "+8-9 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour, Evasion and Energy Shield; +10-11 to maximum Life",
+    "display": "15-17% increased Armour, Evasion and Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLife2_",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlife2_",
+      "15-17% increased armour, evasion and energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour, Evasion and Energy Shield; +12-14 to maximum Life",
+    "display": "18-21% increased Armour, Evasion and Energy Shield; +12-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLife3_",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlife3_",
+      "18-21% increased armour, evasion and energy shield",
+      "+12-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour and Evasion; +10-11 to maximum Life",
+    "display": "12-14% increased Armour and Evasion; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLifeMed1__",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlifemed1__",
+      "12-14% increased armour and evasion",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour and Evasion; +12-13 to maximum Life",
+    "display": "15-17% increased Armour and Evasion; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLifeMed2_",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlifemed2_",
+      "15-17% increased armour and evasion",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour and Evasion; +14-16 to maximum Life",
+    "display": "18-21% increased Armour and Evasion; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLifeMed3",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlifemed3",
+      "18-21% increased armour and evasion",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour and Energy Shield; +10-11 to maximum Life",
+    "display": "12-14% increased Armour and Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLifeMed1__",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlifemed1__",
+      "12-14% increased armour and energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour and Energy Shield; +12-13 to maximum Life",
+    "display": "15-17% increased Armour and Energy Shield; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLifeMed2",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlifemed2",
+      "15-17% increased armour and energy shield",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour and Energy Shield; +14-16 to maximum Life",
+    "display": "18-21% increased Armour and Energy Shield; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLifeMed3_",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlifemed3_",
+      "18-21% increased armour and energy shield",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Evasion and Energy Shield; +10-11 to maximum Life",
+    "display": "12-14% increased Evasion and Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLifeMed1",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlifemed1",
+      "12-14% increased evasion and energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Evasion and Energy Shield; +12-13 to maximum Life",
+    "display": "15-17% increased Evasion and Energy Shield; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLifeMed2",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlifemed2",
+      "15-17% increased evasion and energy shield",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Evasion and Energy Shield; +14-16 to maximum Life",
+    "display": "18-21% increased Evasion and Energy Shield; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLifeMed3",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlifemed3",
+      "18-21% increased evasion and energy shield",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour; +10-11 to maximum Life",
+    "display": "12-14% increased Armour; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLifeMed1",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlifemed1",
+      "12-14% increased armour",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour; +12-13 to maximum Life",
+    "display": "15-17% increased Armour; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLifeMed2",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlifemed2",
+      "15-17% increased armour",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour; +14-16 to maximum Life",
+    "display": "18-21% increased Armour; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLifeMed3",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlifemed3",
+      "18-21% increased armour",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Evasion Rating; +10-11 to maximum Life",
+    "display": "12-14% increased Evasion Rating; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLifeMed1",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlifemed1",
+      "12-14% increased evasion rating",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Evasion Rating; +12-13 to maximum Life",
+    "display": "15-17% increased Evasion Rating; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLifeMed2",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlifemed2",
+      "15-17% increased evasion rating",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Evasion Rating; +14-16 to maximum Life",
+    "display": "18-21% increased Evasion Rating; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLifeMed3_",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlifemed3_",
+      "18-21% increased evasion rating",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Energy Shield; +10-11 to maximum Life",
+    "display": "12-14% increased Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLifeMed1",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlifemed1",
+      "12-14% increased energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Energy Shield; +12-13 to maximum Life",
+    "display": "15-17% increased Energy Shield; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLifeMed2",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlifemed2",
+      "15-17% increased energy shield",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Energy Shield; +14-16 to maximum Life",
+    "display": "18-21% increased Energy Shield; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLifeMed3",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlifemed3",
+      "18-21% increased energy shield",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour, Evasion and Energy Shield; +10-11 to maximum Life",
+    "display": "12-14% increased Armour, Evasion and Energy Shield; +10-11 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLifeMed1_",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlifemed1_",
+      "12-14% increased armour, evasion and energy shield",
+      "+10-11 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour, Evasion and Energy Shield; +12-13 to maximum Life",
+    "display": "15-17% increased Armour, Evasion and Energy Shield; +12-13 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLifeMed2",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlifemed2",
+      "15-17% increased armour, evasion and energy shield",
+      "+12-13 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour, Evasion and Energy Shield; +14-16 to maximum Life",
+    "display": "18-21% increased Armour, Evasion and Energy Shield; +14-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLifeMed3",
+    "item_classes": [
+      "Helmet",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlifemed3",
+      "18-21% increased armour, evasion and energy shield",
+      "+14-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour and Evasion; +13-14 to maximum Life",
+    "display": "12-14% increased Armour and Evasion; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLifeHigh1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlifehigh1",
+      "12-14% increased armour and evasion",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour and Evasion; +15-16 to maximum Life",
+    "display": "15-17% increased Armour and Evasion; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlifehigh2",
+      "15-17% increased armour and evasion",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour and Evasion; +17-19 to maximum Life",
+    "display": "18-21% increased Armour and Evasion; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEvasionAndLifeHigh3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandevasionandlifehigh3",
+      "18-21% increased armour and evasion",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour and Energy Shield; +13-14 to maximum Life",
+    "display": "12-14% increased Armour and Energy Shield; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLifeHigh1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlifehigh1",
+      "12-14% increased armour and energy shield",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour and Energy Shield; +15-16 to maximum Life",
+    "display": "15-17% increased Armour and Energy Shield; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlifehigh2",
+      "15-17% increased armour and energy shield",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour and Energy Shield; +17-19 to maximum Life",
+    "display": "18-21% increased Armour and Energy Shield; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndEnergyShieldAndLifeHigh3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandenergyshieldandlifehigh3",
+      "18-21% increased armour and energy shield",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Evasion and Energy Shield; +13-14 to maximum Life",
+    "display": "12-14% increased Evasion and Energy Shield; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLifeHigh1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlifehigh1",
+      "12-14% increased evasion and energy shield",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Evasion and Energy Shield; +15-16 to maximum Life",
+    "display": "15-17% increased Evasion and Energy Shield; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlifehigh2",
+      "15-17% increased evasion and energy shield",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Evasion and Energy Shield; +17-19 to maximum Life",
+    "display": "18-21% increased Evasion and Energy Shield; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndEnergyShieldAndLifeHigh3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandenergyshieldandlifehigh3",
+      "18-21% increased evasion and energy shield",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour; +13-14 to maximum Life",
+    "display": "12-14% increased Armour; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLifeHigh1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlifehigh1",
+      "12-14% increased armour",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour; +15-16 to maximum Life",
+    "display": "15-17% increased Armour; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlifehigh2",
+      "15-17% increased armour",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour; +17-19 to maximum Life",
+    "display": "18-21% increased Armour; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedArmourAndLifeHigh3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedarmourandlifehigh3",
+      "18-21% increased armour",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Evasion Rating; +13-14 to maximum Life",
+    "display": "12-14% increased Evasion Rating; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLifeHigh1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlifehigh1",
+      "12-14% increased evasion rating",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Evasion Rating; +15-16 to maximum Life",
+    "display": "15-17% increased Evasion Rating; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlifehigh2",
+      "15-17% increased evasion rating",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Evasion Rating; +17-19 to maximum Life",
+    "display": "18-21% increased Evasion Rating; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEvasionAndLifeHigh3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedevasionandlifehigh3",
+      "18-21% increased evasion rating",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Energy Shield; +13-14 to maximum Life",
+    "display": "12-14% increased Energy Shield; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLifeHigh1_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlifehigh1_",
+      "12-14% increased energy shield",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Energy Shield; +15-16 to maximum Life",
+    "display": "15-17% increased Energy Shield; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlifehigh2",
+      "15-17% increased energy shield",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Energy Shield; +17-19 to maximum Life",
+    "display": "18-21% increased Energy Shield; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedEnergyShieldAndLifeHigh3_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreasedenergyshieldandlifehigh3_",
+      "18-21% increased energy shield",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Armour, Evasion and Energy Shield; +13-14 to maximum Life",
+    "display": "12-14% increased Armour, Evasion and Energy Shield; +13-14 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLifeHigh1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlifehigh1",
+      "12-14% increased armour, evasion and energy shield",
+      "+13-14 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Armour, Evasion and Energy Shield; +15-16 to maximum Life",
+    "display": "15-17% increased Armour, Evasion and Energy Shield; +15-16 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLifeHigh2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlifehigh2",
+      "15-17% increased armour, evasion and energy shield",
+      "+15-16 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-21% increased Armour, Evasion and Energy Shield; +17-19 to maximum Life",
+    "display": "18-21% increased Armour, Evasion and Energy Shield; +17-19 to maximum Life",
+    "identifier": "JunMaster2LocalIncreasedDefencesAndLifeHigh3_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2localincreaseddefencesandlifehigh3_",
+      "18-21% increased armour, evasion and energy shield",
+      "+17-19 to maximum life"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+10-15 to Strength and Dexterity",
+    "display": "+10-15 to Strength and Dexterity",
+    "identifier": "JunMaster2StrengthAndDexterity1__",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2strengthanddexterity1__",
+      "+10-15 to strength and dexterity"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-20 to Strength and Dexterity",
+    "display": "+16-20 to Strength and Dexterity",
+    "identifier": "JunMaster2StrengthAndDexterity2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2strengthanddexterity2",
+      "+16-20 to strength and dexterity"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-25 to Strength and Dexterity",
+    "display": "+21-25 to Strength and Dexterity",
+    "identifier": "JunMaster2StrengthAndDexterity3_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2strengthanddexterity3_",
+      "+21-25 to strength and dexterity"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+10-15 to Dexterity and Intelligence",
+    "display": "+10-15 to Dexterity and Intelligence",
+    "identifier": "JunMaster2DexterityAndIntelligence1_",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2dexterityandintelligence1_",
+      "+10-15 to dexterity and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-20 to Dexterity and Intelligence",
+    "display": "+16-20 to Dexterity and Intelligence",
+    "identifier": "JunMaster2DexterityAndIntelligence2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2dexterityandintelligence2",
+      "+16-20 to dexterity and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-25 to Dexterity and Intelligence",
+    "display": "+21-25 to Dexterity and Intelligence",
+    "identifier": "JunMaster2DexterityAndIntelligence3__",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2dexterityandintelligence3__",
+      "+21-25 to dexterity and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+10-15 to Strength and Intelligence",
+    "display": "+10-15 to Strength and Intelligence",
+    "identifier": "JunMaster2StrengthAndIntelligence1",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2strengthandintelligence1",
+      "+10-15 to strength and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-20 to Strength and Intelligence",
+    "display": "+16-20 to Strength and Intelligence",
+    "identifier": "JunMaster2StrengthAndIntelligence2",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2strengthandintelligence2",
+      "+16-20 to strength and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-25 to Strength and Intelligence",
+    "display": "+21-25 to Strength and Intelligence",
+    "identifier": "JunMaster2StrengthAndIntelligence3",
+    "item_classes": [
+      "Body Armour",
+      "Boots",
+      "Gloves",
+      "Helmet",
+      "Shield",
+      "Amulet",
+      "Belt",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2strengthandintelligence3",
+      "+21-25 to strength and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "+1 to Minimum Endurance Charges",
+    "display": "+1 to Minimum Endurance Charges",
+    "identifier": "JunMaster2MinimumEnduranceCharges1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2minimumendurancecharges1",
+      "+1 to minimum endurance charges"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "+1 to Minimum Power Charges",
+    "display": "+1 to Minimum Power Charges",
+    "identifier": "JunMaster2MinimumPowerCharges1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2minimumpowercharges1",
+      "+1 to minimum power charges"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "+1 to Minimum Frenzy Charges",
+    "display": "+1 to Minimum Frenzy Charges",
+    "identifier": "JunMaster2MinimumFrenzyCharges1_",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2minimumfrenzycharges1_",
+      "+1 to minimum frenzy charges"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+26-30 to maximum Mana; Regenerate 120 Mana per second",
+    "display": "+26-30 to maximum Mana; Regenerate 120 Mana per second",
+    "identifier": "JunMaster2IncreasedManaAndRegen1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2increasedmanaandregen1",
+      "+26-30 to maximum mana",
+      "regenerate 120 mana per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+31-35 to maximum Mana; Regenerate 180 Mana per second",
+    "display": "+31-35 to maximum Mana; Regenerate 180 Mana per second",
+    "identifier": "JunMaster2IncreasedManaAndRegen2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2increasedmanaandregen2",
+      "+31-35 to maximum mana",
+      "regenerate 180 mana per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+36-40 to maximum Mana; Regenerate 240 Mana per second",
+    "display": "+36-40 to maximum Mana; Regenerate 240 Mana per second",
+    "identifier": "JunMaster2IncreasedManaAndRegen3",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2increasedmanaandregen3",
+      "+36-40 to maximum mana",
+      "regenerate 240 mana per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+26-30 to maximum Mana; 3% reduced Mana Cost of Skills",
+    "display": "+26-30 to maximum Mana; 3% reduced Mana Cost of Skills",
+    "identifier": "JunMaster2ManaAndManaCostPercent1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2manaandmanacostpercent1",
+      "+26-30 to maximum mana",
+      "3% reduced mana cost of skills"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+31-35 to maximum Mana; 4% reduced Mana Cost of Skills",
+    "display": "+31-35 to maximum Mana; 4% reduced Mana Cost of Skills",
+    "identifier": "JunMaster2ManaAndManaCostPercent2_",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2manaandmanacostpercent2_",
+      "+31-35 to maximum mana",
+      "4% reduced mana cost of skills"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+36-40 to maximum Mana; 5% reduced Mana Cost of Skills",
+    "display": "+36-40 to maximum Mana; 5% reduced Mana Cost of Skills",
+    "identifier": "JunMaster2ManaAndManaCostPercent3",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2manaandmanacostpercent3",
+      "+36-40 to maximum mana",
+      "5% reduced mana cost of skills"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "+26-30 to maximum Mana; 4% of Damage taken Recouped as Mana",
+    "display": "+26-30 to maximum Mana; 4% of Damage taken Recouped as Mana",
+    "identifier": "JunMaster2ManaAndDamageTakenGoesToManaPercent1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2manaanddamagetakengoestomanapercent1",
+      "+26-30 to maximum mana",
+      "4% of damage taken recouped as mana"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+31-35 to maximum Mana; 5% of Damage taken Recouped as Mana",
+    "display": "+31-35 to maximum Mana; 5% of Damage taken Recouped as Mana",
+    "identifier": "JunMaster2ManaAndDamageTakenGoesToManaPercent2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2manaanddamagetakengoestomanapercent2",
+      "+31-35 to maximum mana",
+      "5% of damage taken recouped as mana"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+36-40 to maximum Mana; 6% of Damage taken Recouped as Mana",
+    "display": "+36-40 to maximum Mana; 6% of Damage taken Recouped as Mana",
+    "identifier": "JunMaster2ManaAndDamageTakenGoesToManaPercent3",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2manaanddamagetakengoestomanapercent3",
+      "+36-40 to maximum mana",
+      "6% of damage taken recouped as mana"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "3% increased Attack and Cast Speed",
+    "display": "3% increased Attack and Cast Speed",
+    "identifier": "JunMaster2AttackAndCastSpeed1",
+    "item_classes": [
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2attackandcastspeed1",
+      "3% increased attack and cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "4% increased Attack and Cast Speed",
+    "display": "4% increased Attack and Cast Speed",
+    "identifier": "JunMaster2AttackAndCastSpeed2_",
+    "item_classes": [
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2attackandcastspeed2_",
+      "4% increased attack and cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-6% increased Attack and Cast Speed",
+    "display": "5-6% increased Attack and Cast Speed",
+    "identifier": "JunMaster2AttackAndCastSpeed3",
+    "item_classes": [
+      "Amulet",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2attackandcastspeed3",
+      "5-6% increased attack and cast speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "13-14% increased Movement Speed; 6-9% increased Movement Speed if you haven't been Hit Recently",
+    "display": "13-14% increased Movement Speed; 6-9% increased Movement Speed if you haven't been Hit Recently",
+    "identifier": "JunMaster2MovementVelocityAndMovementVelocityIfNotHitRecently1__",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandmovementvelocityifnothitrecently1__",
+      "13-14% increased movement speed",
+      "6-9% increased movement speed if you haven't been hit recently"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Movement Speed; 6-9% increased Movement Speed if you haven't been Hit Recently",
+    "display": "15-17% increased Movement Speed; 6-9% increased Movement Speed if you haven't been Hit Recently",
+    "identifier": "JunMaster2MovementVelocityAndMovementVelocityIfNotHitRecently2__",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandmovementvelocityifnothitrecently2__",
+      "15-17% increased movement speed",
+      "6-9% increased movement speed if you haven't been hit recently"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-20% increased Movement Speed; 6-9% increased Movement Speed if you haven't been Hit Recently",
+    "display": "18-20% increased Movement Speed; 6-9% increased Movement Speed if you haven't been Hit Recently",
+    "identifier": "JunMaster2MovementVelocityAndMovementVelocityIfNotHitRecently3",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandmovementvelocityifnothitrecently3",
+      "18-20% increased movement speed",
+      "6-9% increased movement speed if you haven't been hit recently"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "13-14% increased Movement Speed; 8-12% chance to gain Onslaught for 4 seconds on Kill",
+    "display": "13-14% increased Movement Speed; 8-12% chance to gain Onslaught for 4 seconds on Kill",
+    "identifier": "JunMaster2MovementVelocityAndOnslaughtOnKill1",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandonslaughtonkill1",
+      "13-14% increased movement speed",
+      "8-12% chance to gain onslaught for 4 seconds on kill"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Movement Speed; 8-12% chance to gain Onslaught for 4 seconds on Kill",
+    "display": "15-17% increased Movement Speed; 8-12% chance to gain Onslaught for 4 seconds on Kill",
+    "identifier": "JunMaster2MovementVelocityAndOnslaughtOnKill2",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandonslaughtonkill2",
+      "15-17% increased movement speed",
+      "8-12% chance to gain onslaught for 4 seconds on kill"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-20% increased Movement Speed; 8-12% chance to gain Onslaught for 4 seconds on Kill",
+    "display": "18-20% increased Movement Speed; 8-12% chance to gain Onslaught for 4 seconds on Kill",
+    "identifier": "JunMaster2MovementVelocityAndOnslaughtOnKill3_",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandonslaughtonkill3_",
+      "18-20% increased movement speed",
+      "8-12% chance to gain onslaught for 4 seconds on kill"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "13-14% increased Movement Speed; 100% chance to Avoid being Chilled",
+    "display": "13-14% increased Movement Speed; 100% chance to Avoid being Chilled",
+    "identifier": "JunMaster2MovementVelocityAndCannotBeChilled1_",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandcannotbechilled1_",
+      "13-14% increased movement speed",
+      "100% chance to avoid being chilled"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-17% increased Movement Speed; 100% chance to Avoid being Chilled",
+    "display": "15-17% increased Movement Speed; 100% chance to Avoid being Chilled",
+    "identifier": "JunMaster2MovementVelocityAndCannotBeChilled2",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandcannotbechilled2",
+      "15-17% increased movement speed",
+      "100% chance to avoid being chilled"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "18-20% increased Movement Speed; 100% chance to Avoid being Chilled",
+    "display": "18-20% increased Movement Speed; 100% chance to Avoid being Chilled",
+    "identifier": "JunMaster2MovementVelocityAndCannotBeChilled3",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2movementvelocityandcannotbechilled3",
+      "18-20% increased movement speed",
+      "100% chance to avoid being chilled"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+105-150 to Armour and Evasion Rating",
+    "display": "+105-150 to Armour and Evasion Rating",
+    "identifier": "JunMaster2ArmourAndEvasionRating1_",
+    "item_classes": [
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2armourandevasionrating1_",
+      "+105-150 to armour and evasion rating"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+151-213 to Armour and Evasion Rating",
+    "display": "+151-213 to Armour and Evasion Rating",
+    "identifier": "JunMaster2ArmourAndEvasionRating2",
+    "item_classes": [
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2armourandevasionrating2",
+      "+151-213 to armour and evasion rating"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+214-285 to Armour and Evasion Rating",
+    "display": "+214-285 to Armour and Evasion Rating",
+    "identifier": "JunMaster2ArmourAndEvasionRating3",
+    "item_classes": [
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2armourandevasionrating3",
+      "+214-285 to armour and evasion rating"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+105-150 to Armour; +11-15 to maximum Energy Shield",
+    "display": "+105-150 to Armour; +11-15 to maximum Energy Shield",
+    "identifier": "JunMaster2ArmourAndEnergyShield1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2armourandenergyshield1",
+      "+105-150 to armour",
+      "+11-15 to maximum energy shield"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+151-213 to Armour; +16-20 to maximum Energy Shield",
+    "display": "+151-213 to Armour; +16-20 to maximum Energy Shield",
+    "identifier": "JunMaster2ArmourAndEnergyShield2__",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2armourandenergyshield2__",
+      "+151-213 to armour",
+      "+16-20 to maximum energy shield"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+214-285 to Armour; +21-25 to maximum Energy Shield",
+    "display": "+214-285 to Armour; +21-25 to maximum Energy Shield",
+    "identifier": "JunMaster2ArmourAndEnergyShield3",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2armourandenergyshield3",
+      "+214-285 to armour",
+      "+21-25 to maximum energy shield"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+105-150 to Evasion Rating; +11-15 to maximum Energy Shield",
+    "display": "+105-150 to Evasion Rating; +11-15 to maximum Energy Shield",
+    "identifier": "JunMaster2EvasionRatingAndEnergyShield1__",
+    "item_classes": [
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2evasionratingandenergyshield1__",
+      "+105-150 to evasion rating",
+      "+11-15 to maximum energy shield"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+151-213 to Evasion Rating; +16-20 to maximum Energy Shield",
+    "display": "+151-213 to Evasion Rating; +16-20 to maximum Energy Shield",
+    "identifier": "JunMaster2EvasionRatingAndEnergyShield2",
+    "item_classes": [
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2evasionratingandenergyshield2",
+      "+151-213 to evasion rating",
+      "+16-20 to maximum energy shield"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+214-285 to Evasion Rating; +21-25 to maximum Energy Shield",
+    "display": "+214-285 to Evasion Rating; +21-25 to maximum Energy Shield",
+    "identifier": "JunMaster2EvasionRatingAndEnergyShield3",
+    "item_classes": [
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2evasionratingandenergyshield3",
+      "+214-285 to evasion rating",
+      "+21-25 to maximum energy shield"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "5-6% chance for Flasks you use to not consume Charges",
+    "display": "5-6% chance for Flasks you use to not consume Charges",
+    "identifier": "JunMaster2ChanceToNotConsumeFlaskCharges1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2chancetonotconsumeflaskcharges1",
+      "5-6% chance for flasks you use to not consume charges"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "7-8% chance for Flasks you use to not consume Charges",
+    "display": "7-8% chance for Flasks you use to not consume Charges",
+    "identifier": "JunMaster2ChanceToNotConsumeFlaskCharges2",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2chancetonotconsumeflaskcharges2",
+      "7-8% chance for flasks you use to not consume charges"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Flasks applied to you have 8-10% increased Effect; -20% increased Flask Charges gained",
+    "display": "Flasks applied to you have 8-10% increased Effect; -20% increased Flask Charges gained",
+    "identifier": "JunMaster2FlaskEffectAndFlaskChargesGained1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2flaskeffectandflaskchargesgained1",
+      "flasks applied to you have 8-10% increased effect",
+      "-20% increased flask charges gained"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "Flasks applied to you have 11-14% increased Effect; -33% increased Flask Charges gained",
+    "display": "Flasks applied to you have 11-14% increased Effect; -33% increased Flask Charges gained",
+    "identifier": "JunMaster2FlaskEffectAndFlaskChargesGained2",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2flaskeffectandflaskchargesgained2",
+      "flasks applied to you have 11-14% increased effect",
+      "-33% increased flask charges gained"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "6-8% increased Cooldown Recovery Rate",
+    "display": "6-8% increased Cooldown Recovery Rate",
+    "identifier": "JunMaster2GlobalCooldownRecovery1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2globalcooldownrecovery1",
+      "6-8% increased cooldown recovery rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "9-12% increased Cooldown Recovery Rate",
+    "display": "9-12% increased Cooldown Recovery Rate",
+    "identifier": "JunMaster2GlobalCooldownRecovery2",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2globalcooldownrecovery2",
+      "9-12% increased cooldown recovery rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-6% increased Damage per Endurance Charge",
+    "display": "5-6% increased Damage per Endurance Charge",
+    "identifier": "JunMaster2DamagePerEnduranceCharge2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2damageperendurancecharge2h1",
+      "5-6% increased damage per endurance charge"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "3-4% increased Damage per Endurance Charge",
+    "display": "3-4% increased Damage per Endurance Charge",
+    "identifier": "JunMaster2DamagePerEnduranceCharge1h1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2damageperendurancecharge1h1_",
+      "3-4% increased damage per endurance charge"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-6% increased Damage per Frenzy Charge",
+    "display": "5-6% increased Damage per Frenzy Charge",
+    "identifier": "JunMaster2DamagePerFrenzyCharge2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2damageperfrenzycharge2h1",
+      "5-6% increased damage per frenzy charge"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "3-4% increased Damage per Frenzy Charge",
+    "display": "3-4% increased Damage per Frenzy Charge",
+    "identifier": "JunMaster2DamagePerFrenzyCharge1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2damageperfrenzycharge1h1",
+      "3-4% increased damage per frenzy charge"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-6% increased Damage per Power Charge",
+    "display": "5-6% increased Damage per Power Charge",
+    "identifier": "JunMaster2DamagePerPowerCharge2h1__",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2damageperpowercharge2h1__",
+      "5-6% increased damage per power charge"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "3-4% increased Damage per Power Charge",
+    "display": "3-4% increased Damage per Power Charge",
+    "identifier": "JunMaster2DamagePerPowerCharge1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2damageperpowercharge1h1",
+      "3-4% increased damage per power charge"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "20-25% of Physical Damage Converted to Fire Damage",
+    "display": "20-25% of Physical Damage Converted to Fire Damage",
+    "identifier": "JunMaster2PhysicalDamageConvertedToFire1",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageconvertedtofire1",
+      "20-25% of physical damage converted to fire damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "20-25% of Physical Damage Converted to Cold Damage",
+    "display": "20-25% of Physical Damage Converted to Cold Damage",
+    "identifier": "JunMaster2PhysicalDamageConvertedToCold1",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageconvertedtocold1",
+      "20-25% of physical damage converted to cold damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "20-25% of Physical Damage Converted to Lightning Damage",
+    "display": "20-25% of Physical Damage Converted to Lightning Damage",
+    "identifier": "JunMaster2PhysicalDamageConvertedToLightning1",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2physicaldamageconvertedtolightning1",
+      "20-25% of physical damage converted to lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+1 to maximum number of Raised Zombies; +1 to maximum number of Skeletons; +0 to maximum number of Spectres",
+    "display": "+1 to maximum number of Raised Zombies; +1 to maximum number of Skeletons; +0 to maximum number of Spectres",
+    "identifier": "JunMaster2MaximumZombieAndSkeleton1_",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2maximumzombieandskeleton1_",
+      "+1 to maximum number of raised zombies",
+      "+1 to maximum number of skeletons",
+      "+0 to maximum number of spectres"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "16-22% increased Effect of Non-Damaging Ailments",
+    "display": "16-22% increased Effect of Non-Damaging Ailments",
+    "identifier": "JunMaster2EffectOfAilments1_",
+    "item_classes": [
+      "Boots",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2effectofailments1_",
+      "16-22% increased effect of non-damaging ailments"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "23-30% increased Effect of Non-Damaging Ailments",
+    "display": "23-30% increased Effect of Non-Damaging Ailments",
+    "identifier": "JunMaster2EffectOfAilments2",
+    "item_classes": [
+      "Boots",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2effectofailments2",
+      "23-30% increased effect of non-damaging ailments"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "6-7% increased Effect of your Curses",
+    "display": "6-7% increased Effect of your Curses",
+    "identifier": "JunMaster2CurseEffect1",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2curseeffect1",
+      "6-7% increased effect of your curses"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "8-10% increased Effect of your Curses",
+    "display": "8-10% increased Effect of your Curses",
+    "identifier": "JunMaster2CurseEffect2",
+    "item_classes": [
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2curseeffect2",
+      "8-10% increased effect of your curses"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "6-7% chance to Avoid Elemental Damage from Hits during Soul Gain Prevention",
+    "display": "6-7% chance to Avoid Elemental Damage from Hits during Soul Gain Prevention",
+    "identifier": "JunMaster2AvoidElementalDamageChanceDuringSoulGainPrevention1",
+    "item_classes": [
+      "Body Armour",
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2avoidelementaldamagechanceduringsoulgainprevention1",
+      "6-7% chance to avoid elemental damage from hits during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "8-9% chance to Avoid Elemental Damage from Hits during Soul Gain Prevention",
+    "display": "8-9% chance to Avoid Elemental Damage from Hits during Soul Gain Prevention",
+    "identifier": "JunMaster2AvoidElementalDamageChanceDuringSoulGainPrevention2",
+    "item_classes": [
+      "Body Armour",
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2avoidelementaldamagechanceduringsoulgainprevention2",
+      "8-9% chance to avoid elemental damage from hits during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "+1000-1600 to Armour during Soul Gain Prevention",
+    "display": "+1000-1600 to Armour during Soul Gain Prevention",
+    "identifier": "JunMaster2PhysicalDamageReductionRatingDuringSoulGainPrevention1_",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagereductionratingduringsoulgainprevention1_",
+      "+1000-1600 to armour during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "+1601-2200 to Armour during Soul Gain Prevention",
+    "display": "+1601-2200 to Armour during Soul Gain Prevention",
+    "identifier": "JunMaster2PhysicalDamageReductionRatingDuringSoulGainPrevention2",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagereductionratingduringsoulgainprevention2",
+      "+1601-2200 to armour during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "+2201-3000 to Armour during Soul Gain Prevention",
+    "display": "+2201-3000 to Armour during Soul Gain Prevention",
+    "identifier": "JunMaster2PhysicalDamageReductionRatingDuringSoulGainPrevention3___",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagereductionratingduringsoulgainprevention3___",
+      "+2201-3000 to armour during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "You have Onslaught during Soul Gain Prevention",
+    "display": "You have Onslaught during Soul Gain Prevention",
+    "identifier": "JunMaster2GainOnslaughtDuringSoulGainPrevention1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2gainonslaughtduringsoulgainprevention1",
+      "you have onslaught during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "30-40% increased Damage with Non-Vaal Skills during Soul Gain Prevention",
+    "display": "30-40% increased Damage with Non-Vaal Skills during Soul Gain Prevention",
+    "identifier": "JunMaster2DamageWithNonVaalSkillsDuringSoulGainPrevention1",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2damagewithnonvaalskillsduringsoulgainprevention1",
+      "30-40% increased damage with non-vaal skills during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "41-50% increased Damage with Non-Vaal Skills during Soul Gain Prevention",
+    "display": "41-50% increased Damage with Non-Vaal Skills during Soul Gain Prevention",
+    "identifier": "JunMaster2DamageWithNonVaalSkillsDuringSoulGainPrevention2",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2damagewithnonvaalskillsduringsoulgainprevention2",
+      "41-50% increased damage with non-vaal skills during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "51-60% increased Damage with Non-Vaal Skills during Soul Gain Prevention",
+    "display": "51-60% increased Damage with Non-Vaal Skills during Soul Gain Prevention",
+    "identifier": "JunMaster2DamageWithNonVaalSkillsDuringSoulGainPrevention3",
+    "item_classes": [
+      "Boots",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2damagewithnonvaalskillsduringsoulgainprevention3",
+      "51-60% increased damage with non-vaal skills during soul gain prevention"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "8-10% increased Area of Effect; +1 to Level of Socketed AoE Gems",
+    "display": "8-10% increased Area of Effect; +1 to Level of Socketed AoE Gems",
+    "identifier": "JunMaster2SkillAreaOfEffectPercentAndAreaOfEffectGemLevel1-",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2skillareaofeffectpercentandareaofeffectgemlevel1-",
+      "8-10% increased area of effect",
+      "+1 to level of socketed aoe gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Projectiles Pierce an additional Target; +1 to Level of Socketed Projectile Gems",
+    "display": "Projectiles Pierce an additional Target; +1 to Level of Socketed Projectile Gems",
+    "identifier": "JunMaster2ProjectilePierceAndProjectileGemLevel1",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2projectilepierceandprojectilegemlevel1",
+      "projectiles pierce an additional target",
+      "+1 to level of socketed projectile gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+2 to Melee Strike Range; +1 to Level of Socketed Melee Gems",
+    "display": "+2 to Melee Strike Range; +1 to Level of Socketed Melee Gems",
+    "identifier": "JunMaster2MeleeRangeAndMeleeGemLevel1_",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2meleerangeandmeleegemlevel1_",
+      "+2 to melee strike range",
+      "+1 to level of socketed melee gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+25-31% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "display": "+25-31% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2CriticalStrikeMultiplierIfRareOrUniqueEnemyNearby2h1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2criticalstrikemultiplierifrareoruniqueenemynearby2h1_",
+      "+25-31% critical strike multiplier while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+32-38% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "display": "+32-38% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2CriticalStrikeMultiplierIfRareOrUniqueEnemyNearby2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2criticalstrikemultiplierifrareoruniqueenemynearby2h2",
+      "+32-38% critical strike multiplier while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+39-45% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "display": "+39-45% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2CriticalStrikeMultiplierIfRareOrUniqueEnemyNearby2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2criticalstrikemultiplierifrareoruniqueenemynearby2h3",
+      "+39-45% critical strike multiplier while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+17-21% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "display": "+17-21% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2CriticalStrikeMultiplierIfRareOrUniqueEnemyNearby1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2criticalstrikemultiplierifrareoruniqueenemynearby1h1",
+      "+17-21% critical strike multiplier while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+22-25% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "display": "+22-25% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2CriticalStrikeMultiplierIfRareOrUniqueEnemyNearby1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2criticalstrikemultiplierifrareoruniqueenemynearby1h2",
+      "+22-25% critical strike multiplier while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+26-30% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "display": "+26-30% Critical Strike Multiplier while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2CriticalStrikeMultiplierIfRareOrUniqueEnemyNearby1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2criticalstrikemultiplierifrareoruniqueenemynearby1h3",
+      "+26-30% critical strike multiplier while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "14-16% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "display": "14-16% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2AttackSpeedPercentIfRareOrUniqueEnemyNearby2h1",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2attackspeedpercentifrareoruniqueenemynearby2h1",
+      "14-16% increased attack speed while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "17-19% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "display": "17-19% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2AttackSpeedPercentIfRareOrUniqueEnemyNearby2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2attackspeedpercentifrareoruniqueenemynearby2h2_",
+      "17-19% increased attack speed while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "20-22% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "display": "20-22% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2AttackSpeedPercentIfRareOrUniqueEnemyNearby2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2attackspeedpercentifrareoruniqueenemynearby2h3",
+      "20-22% increased attack speed while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "7% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "display": "7% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2AttackSpeedPercentIfRareOrUniqueEnemyNearby1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2attackspeedpercentifrareoruniqueenemynearby1h1",
+      "7% increased attack speed while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "8-9% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "display": "8-9% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2AttackSpeedPercentIfRareOrUniqueEnemyNearby1h2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2attackspeedpercentifrareoruniqueenemynearby1h2_",
+      "8-9% increased attack speed while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "10-11% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "display": "10-11% increased Attack Speed while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2AttackSpeedPercentIfRareOrUniqueEnemyNearby1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2attackspeedpercentifrareoruniqueenemynearby1h3",
+      "10-11% increased attack speed while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Regenerate 5400 Energy Shield per second while a Rare or Unique Enemy is Nearby",
+    "display": "Regenerate 5400 Energy Shield per second while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2EnergyShieldRegenerationRatePerMinuteIfRareOrUniqueEnemyNearby1",
+    "item_classes": [
+      "Body Armour",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2energyshieldregenerationrateperminuteifrareoruniqueenemynearby1",
+      "regenerate 5400 energy shield per second while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Regenerate 7200 Energy Shield per second while a Rare or Unique Enemy is Nearby",
+    "display": "Regenerate 7200 Energy Shield per second while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2EnergyShieldRegenerationRatePerMinuteIfRareOrUniqueEnemyNearby2_",
+    "item_classes": [
+      "Body Armour",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2energyshieldregenerationrateperminuteifrareoruniqueenemynearby2_",
+      "regenerate 7200 energy shield per second while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Regenerate 9000 Energy Shield per second while a Rare or Unique Enemy is Nearby",
+    "display": "Regenerate 9000 Energy Shield per second while a Rare or Unique Enemy is Nearby",
+    "identifier": "JunMaster2EnergyShieldRegenerationRatePerMinuteIfRareOrUniqueEnemyNearby3_",
+    "item_classes": [
+      "Body Armour",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2energyshieldregenerationrateperminuteifrareoruniqueenemynearby3_",
+      "regenerate 9000 energy shield per second while a rare or unique enemy is nearby"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "3% chance to gain a Frenzy Charge on Critical Strike; 9-10% increased Global Critical Strike Chance",
+    "display": "3% chance to gain a Frenzy Charge on Critical Strike; 9-10% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndGainFrenzyChargeOnCriticalStrikePercent1",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandgainfrenzychargeoncriticalstrikepercent1",
+      "3% chance to gain a frenzy charge on critical strike",
+      "9-10% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "4% chance to gain a Frenzy Charge on Critical Strike; 11-12% increased Global Critical Strike Chance",
+    "display": "4% chance to gain a Frenzy Charge on Critical Strike; 11-12% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndGainFrenzyChargeOnCriticalStrikePercent2",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandgainfrenzychargeoncriticalstrikepercent2",
+      "4% chance to gain a frenzy charge on critical strike",
+      "11-12% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5% chance to gain a Frenzy Charge on Critical Strike; 13-14% increased Global Critical Strike Chance",
+    "display": "5% chance to gain a Frenzy Charge on Critical Strike; 13-14% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndGainFrenzyChargeOnCriticalStrikePercent3",
+    "item_classes": [
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandgainfrenzychargeoncriticalstrikepercent3",
+      "5% chance to gain a frenzy charge on critical strike",
+      "13-14% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "14-16% increased Elemental Damage if you've dealt a Critical Strike Recently; 11-12% increased Global Critical Strike Chance",
+    "display": "14-16% increased Elemental Damage if you've dealt a Critical Strike Recently; 11-12% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndElementalDamagePercentIfHaveCritRecently1_",
+    "item_classes": [
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandelementaldamagepercentifhavecritrecently1_",
+      "14-16% increased elemental damage if you've dealt a critical strike recently",
+      "11-12% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "17-19% increased Elemental Damage if you've dealt a Critical Strike Recently; 13-14% increased Global Critical Strike Chance",
+    "display": "17-19% increased Elemental Damage if you've dealt a Critical Strike Recently; 13-14% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndElementalDamagePercentIfHaveCritRecently2",
+    "item_classes": [
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandelementaldamagepercentifhavecritrecently2",
+      "17-19% increased elemental damage if you've dealt a critical strike recently",
+      "13-14% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "20-22% increased Elemental Damage if you've dealt a Critical Strike Recently; 15-16% increased Global Critical Strike Chance",
+    "display": "20-22% increased Elemental Damage if you've dealt a Critical Strike Recently; 15-16% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndElementalDamagePercentIfHaveCritRecently3",
+    "item_classes": [
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandelementaldamagepercentifhavecritrecently3",
+      "20-22% increased elemental damage if you've dealt a critical strike recently",
+      "15-16% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Adds 10-11 to 10-11 Chaos Damage if you've dealt a Critical Strike Recently; Adds 14-16 to 14-16 Chaos Damage if you've dealt a Critical Strike Recently; 11-12% increased Global Critical Strike Chance",
+    "display": "Adds 10-11 to 10-11 Chaos Damage if you've dealt a Critical Strike Recently; Adds 14-16 to 14-16 Chaos Damage if you've dealt a Critical Strike Recently; 11-12% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndAddedChaosDamageIfHaveCritRecently1",
+    "item_classes": [
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandaddedchaosdamageifhavecritrecently1",
+      "adds 10-11 to 10-11 chaos damage if you've dealt a critical strike recently",
+      "adds 14-16 to 14-16 chaos damage if you've dealt a critical strike recently",
+      "11-12% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 12-13 to 12-13 Chaos Damage if you've dealt a Critical Strike Recently; Adds 17-20 to 17-20 Chaos Damage if you've dealt a Critical Strike Recently; 13-14% increased Global Critical Strike Chance",
+    "display": "Adds 12-13 to 12-13 Chaos Damage if you've dealt a Critical Strike Recently; Adds 17-20 to 17-20 Chaos Damage if you've dealt a Critical Strike Recently; 13-14% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndAddedChaosDamageIfHaveCritRecently2",
+    "item_classes": [
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandaddedchaosdamageifhavecritrecently2",
+      "adds 12-13 to 12-13 chaos damage if you've dealt a critical strike recently",
+      "adds 17-20 to 17-20 chaos damage if you've dealt a critical strike recently",
+      "13-14% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 14-16 to 14-16 Chaos Damage if you've dealt a Critical Strike Recently; Adds 21-24 to 21-24 Chaos Damage if you've dealt a Critical Strike Recently; 15-16% increased Global Critical Strike Chance",
+    "display": "Adds 14-16 to 14-16 Chaos Damage if you've dealt a Critical Strike Recently; Adds 21-24 to 21-24 Chaos Damage if you've dealt a Critical Strike Recently; 15-16% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalChanceAndAddedChaosDamageIfHaveCritRecently3",
+    "item_classes": [
+      "Gloves",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2criticalchanceandaddedchaosdamageifhavecritrecently3",
+      "adds 14-16 to 14-16 chaos damage if you've dealt a critical strike recently",
+      "adds 21-24 to 21-24 chaos damage if you've dealt a critical strike recently",
+      "15-16% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+28-33 to maximum Life; Regenerate 120 Mana per second",
+    "display": "+28-33 to maximum Life; Regenerate 120 Mana per second",
+    "identifier": "JunMaster2BaseLifeAndManaRegen1",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2baselifeandmanaregen1",
+      "+28-33 to maximum life",
+      "regenerate 120 mana per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+34-40 to maximum Life; Regenerate 180 Mana per second",
+    "display": "+34-40 to maximum Life; Regenerate 180 Mana per second",
+    "identifier": "JunMaster2BaseLifeAndManaRegen2_",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2baselifeandmanaregen2_",
+      "+34-40 to maximum life",
+      "regenerate 180 mana per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+41-45 to maximum Life; Regenerate 240 Mana per second",
+    "display": "+41-45 to maximum Life; Regenerate 240 Mana per second",
+    "identifier": "JunMaster2BaseLifeAndManaRegen3",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2baselifeandmanaregen3",
+      "+41-45 to maximum life",
+      "regenerate 240 mana per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+28-33 to maximum Mana; Regenerate 900 Life per second",
+    "display": "+28-33 to maximum Mana; Regenerate 900 Life per second",
+    "identifier": "JunMaster2BaseManaAndLifeRegen1",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2basemanaandliferegen1",
+      "+28-33 to maximum mana",
+      "regenerate 900 life per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+34-40 to maximum Mana; Regenerate 1200 Life per second",
+    "display": "+34-40 to maximum Mana; Regenerate 1200 Life per second",
+    "identifier": "JunMaster2BaseManaAndLifeRegen2",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2basemanaandliferegen2",
+      "+34-40 to maximum mana",
+      "regenerate 1200 life per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+41-45 to maximum Mana; Regenerate 1500 Life per second",
+    "display": "+41-45 to maximum Mana; Regenerate 1500 Life per second",
+    "identifier": "JunMaster2BaseManaAndLifeRegen3",
+    "item_classes": [
+      "Helmet",
+      "Gloves",
+      "Boots",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2basemanaandliferegen3",
+      "+41-45 to maximum mana",
+      "regenerate 1500 life per second"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "18-20% increased Totem Placement speed",
+    "display": "18-20% increased Totem Placement speed",
+    "identifier": "JunMaster2SummonTotemCastSpeed1",
+    "item_classes": [
+      "Boots",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2summontotemcastspeed1",
+      "18-20% increased totem placement speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "21-25% increased Totem Placement speed",
+    "display": "21-25% increased Totem Placement speed",
+    "identifier": "JunMaster2SummonTotemCastSpeed2",
+    "item_classes": [
+      "Boots",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2summontotemcastspeed2",
+      "21-25% increased totem placement speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "26-30% increased Totem Placement speed",
+    "display": "26-30% increased Totem Placement speed",
+    "identifier": "JunMaster2SummonTotemCastSpeed3",
+    "item_classes": [
+      "Boots",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2summontotemcastspeed3",
+      "26-30% increased totem placement speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 6-7 to 6-7 Fire Damage; Adds 9-10 to 9-10 Fire Damage; Adds 6-7 to 6-7 Cold Damage; Adds 9-10 to 9-10 Cold Damage",
+    "display": "Adds 6-7 to 6-7 Fire Damage; Adds 9-10 to 9-10 Fire Damage; Adds 6-7 to 6-7 Cold Damage; Adds 9-10 to 9-10 Cold Damage",
+    "identifier": "JunMaster2AddedFireAndColdDamage1",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedfireandcolddamage1",
+      "adds 6-7 to 6-7 fire damage",
+      "adds 9-10 to 9-10 fire damage",
+      "adds 6-7 to 6-7 cold damage",
+      "adds 9-10 to 9-10 cold damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 8-9 to 8-9 Fire Damage; Adds 11-13 to 11-13 Fire Damage; Adds 8-9 to 8-9 Cold Damage; Adds 11-13 to 11-13 Cold Damage",
+    "display": "Adds 8-9 to 8-9 Fire Damage; Adds 11-13 to 11-13 Fire Damage; Adds 8-9 to 8-9 Cold Damage; Adds 11-13 to 11-13 Cold Damage",
+    "identifier": "JunMaster2AddedFireAndColdDamage2__",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedfireandcolddamage2__",
+      "adds 8-9 to 8-9 fire damage",
+      "adds 11-13 to 11-13 fire damage",
+      "adds 8-9 to 8-9 cold damage",
+      "adds 11-13 to 11-13 cold damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 10-12 to 10-12 Fire Damage; Adds 14-16 to 14-16 Fire Damage; Adds 10-12 to 10-12 Cold Damage; Adds 14-16 to 14-16 Cold Damage",
+    "display": "Adds 10-12 to 10-12 Fire Damage; Adds 14-16 to 14-16 Fire Damage; Adds 10-12 to 10-12 Cold Damage; Adds 14-16 to 14-16 Cold Damage",
+    "identifier": "JunMaster2AddedFireAndColdDamage3",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedfireandcolddamage3",
+      "adds 10-12 to 10-12 fire damage",
+      "adds 14-16 to 14-16 fire damage",
+      "adds 10-12 to 10-12 cold damage",
+      "adds 14-16 to 14-16 cold damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 6-7 to 6-7 Fire Damage; Adds 9-10 to 9-10 Fire Damage; Adds 1 to 1 Lightning Damage; Adds 14-16 to 14-16 Lightning Damage",
+    "display": "Adds 6-7 to 6-7 Fire Damage; Adds 9-10 to 9-10 Fire Damage; Adds 1 to 1 Lightning Damage; Adds 14-16 to 14-16 Lightning Damage",
+    "identifier": "JunMaster2AddedFireAndLightningDamage1",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedfireandlightningdamage1",
+      "adds 6-7 to 6-7 fire damage",
+      "adds 9-10 to 9-10 fire damage",
+      "adds 1 to 1 lightning damage",
+      "adds 14-16 to 14-16 lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 8-9 to 8-9 Fire Damage; Adds 11-13 to 11-13 Fire Damage; Adds 1 to 1 Lightning Damage; Adds 17-20 to 17-20 Lightning Damage",
+    "display": "Adds 8-9 to 8-9 Fire Damage; Adds 11-13 to 11-13 Fire Damage; Adds 1 to 1 Lightning Damage; Adds 17-20 to 17-20 Lightning Damage",
+    "identifier": "JunMaster2AddedFireAndLightningDamage2___",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedfireandlightningdamage2___",
+      "adds 8-9 to 8-9 fire damage",
+      "adds 11-13 to 11-13 fire damage",
+      "adds 1 to 1 lightning damage",
+      "adds 17-20 to 17-20 lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 10-12 to 10-12 Fire Damage; Adds 14-16 to 14-16 Fire Damage; Adds 1 to 1 Lightning Damage; Adds 21-24 to 21-24 Lightning Damage",
+    "display": "Adds 10-12 to 10-12 Fire Damage; Adds 14-16 to 14-16 Fire Damage; Adds 1 to 1 Lightning Damage; Adds 21-24 to 21-24 Lightning Damage",
+    "identifier": "JunMaster2AddedFireAndLightningDamage3",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedfireandlightningdamage3",
+      "adds 10-12 to 10-12 fire damage",
+      "adds 14-16 to 14-16 fire damage",
+      "adds 1 to 1 lightning damage",
+      "adds 21-24 to 21-24 lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "Adds 6-7 to 6-7 Cold Damage; Adds 9-10 to 9-10 Cold Damage; Adds 1 to 1 Lightning Damage; Adds 14-16 to 14-16 Lightning Damage",
+    "display": "Adds 6-7 to 6-7 Cold Damage; Adds 9-10 to 9-10 Cold Damage; Adds 1 to 1 Lightning Damage; Adds 14-16 to 14-16 Lightning Damage",
+    "identifier": "JunMaster2AddedColdAndLightningDamage1",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedcoldandlightningdamage1",
+      "adds 6-7 to 6-7 cold damage",
+      "adds 9-10 to 9-10 cold damage",
+      "adds 1 to 1 lightning damage",
+      "adds 14-16 to 14-16 lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 8-9 to 8-9 Cold Damage; Adds 11-13 to 11-13 Cold Damage; Adds 1 to 1 Lightning Damage; Adds 17-20 to 17-20 Lightning Damage",
+    "display": "Adds 8-9 to 8-9 Cold Damage; Adds 11-13 to 11-13 Cold Damage; Adds 1 to 1 Lightning Damage; Adds 17-20 to 17-20 Lightning Damage",
+    "identifier": "JunMaster2AddedColdAndLightningDamage2",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedcoldandlightningdamage2",
+      "adds 8-9 to 8-9 cold damage",
+      "adds 11-13 to 11-13 cold damage",
+      "adds 1 to 1 lightning damage",
+      "adds 17-20 to 17-20 lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 10-12 to 10-12 Cold Damage; Adds 14-16 to 14-16 Cold Damage; Adds 1 to 1 Lightning Damage; Adds 21-24 to 21-24 Lightning Damage",
+    "display": "Adds 10-12 to 10-12 Cold Damage; Adds 14-16 to 14-16 Cold Damage; Adds 1 to 1 Lightning Damage; Adds 21-24 to 21-24 Lightning Damage",
+    "identifier": "JunMaster2AddedColdAndLightningDamage3_",
+    "item_classes": [
+      "Shield",
+      "Ring",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2addedcoldandlightningdamage3_",
+      "adds 10-12 to 10-12 cold damage",
+      "adds 14-16 to 14-16 cold damage",
+      "adds 1 to 1 lightning damage",
+      "adds 21-24 to 21-24 lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 9,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Your Critical Strike Chance is Lucky while Focused; grant_focus_skill 1",
+    "display": "Your Critical Strike Chance is Lucky while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2LuckyCriticalsDuringFocus1",
+    "item_classes": [
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2luckycriticalsduringfocus1",
+      "your critical strike chance is lucky while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "16-18% increased Evasion Rating while Focused; grant_focus_skill 1",
+    "display": "16-18% increased Evasion Rating while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2DodgeChanceDuringFocus1_",
+    "item_classes": [
+      "Helmet",
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2dodgechanceduringfocus1_",
+      "16-18% increased evasion rating while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "19-22% increased Evasion Rating while Focused; grant_focus_skill 1",
+    "display": "19-22% increased Evasion Rating while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2DodgeChanceDuringFocus2",
+    "item_classes": [
+      "Helmet",
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2dodgechanceduringfocus2",
+      "19-22% increased evasion rating while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "23-25% increased Evasion Rating while Focused; grant_focus_skill 1",
+    "display": "23-25% increased Evasion Rating while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2DodgeChanceDuringFocus3",
+    "item_classes": [
+      "Helmet",
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2dodgechanceduringfocus3",
+      "23-25% increased evasion rating while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "8% additional Physical Damage Reduction while Focused; grant_focus_skill 1",
+    "display": "8% additional Physical Damage Reduction while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2PhysicalDamageReductionDuringFocus1",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagereductionduringfocus1",
+      "8% additional physical damage reduction while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-10% additional Physical Damage Reduction while Focused; grant_focus_skill 1",
+    "display": "9-10% additional Physical Damage Reduction while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2PhysicalDamageReductionDuringFocus2__",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagereductionduringfocus2__",
+      "9-10% additional physical damage reduction while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-12% additional Physical Damage Reduction while Focused; grant_focus_skill 1",
+    "display": "11-12% additional Physical Damage Reduction while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2PhysicalDamageReductionDuringFocus3_",
+    "item_classes": [
+      "Helmet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagereductionduringfocus3_",
+      "11-12% additional physical damage reduction while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Shock nearby Enemies for 2000 Seconds when you Focus; grant_focus_skill 1",
+    "display": "Shock nearby Enemies for 2000 Seconds when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2ShockNearbyEnemiesOnFocus1",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2shocknearbyenemiesonfocus1",
+      "shock nearby enemies for 2000 seconds when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Shock nearby Enemies for 3000 Seconds when you Focus; grant_focus_skill 1",
+    "display": "Shock nearby Enemies for 3000 Seconds when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2ShockNearbyEnemiesOnFocus2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2shocknearbyenemiesonfocus2",
+      "shock nearby enemies for 3000 seconds when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Shock nearby Enemies for 4000 Seconds when you Focus; grant_focus_skill 1",
+    "display": "Shock nearby Enemies for 4000 Seconds when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2ShockNearbyEnemiesOnFocus3",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2shocknearbyenemiesonfocus3",
+      "shock nearby enemies for 4000 seconds when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "60% of Evasion Rating is Regenerated as Life per second while Focused; grant_focus_skill 1",
+    "display": "60% of Evasion Rating is Regenerated as Life per second while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2LifeRegenerationPerEvasionDuringFocus1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2liferegenerationperevasionduringfocus1",
+      "60% of evasion rating is regenerated as life per second while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "Recover 23-25% of Mana and Energy Shield when you Focus; grant_focus_skill 1",
+    "display": "Recover 23-25% of Mana and Energy Shield when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2RestoreManaAndEnergyShieldOnFocus1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2restoremanaandenergyshieldonfocus1",
+      "recover 23-25% of mana and energy shield when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Recover 26-28% of Mana and Energy Shield when you Focus; grant_focus_skill 1",
+    "display": "Recover 26-28% of Mana and Energy Shield when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2RestoreManaAndEnergyShieldOnFocus2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2restoremanaandenergyshieldonfocus2",
+      "recover 26-28% of mana and energy shield when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Recover 29-31% of Mana and Energy Shield when you Focus; grant_focus_skill 1",
+    "display": "Recover 29-31% of Mana and Energy Shield when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2RestoreManaAndEnergyShieldOnFocus3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2restoremanaandenergyshieldonfocus3",
+      "recover 29-31% of mana and energy shield when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "16-20% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "display": "16-20% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ChanceToDealDoubleDamageWhileFocused2h1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2chancetodealdoubledamagewhilefocused2h1_",
+      "16-20% chance to deal double damage while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "21-25% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "display": "21-25% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ChanceToDealDoubleDamageWhileFocused2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2chancetodealdoubledamagewhilefocused2h2",
+      "21-25% chance to deal double damage while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "26-30% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "display": "26-30% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ChanceToDealDoubleDamageWhileFocused2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2chancetodealdoubledamagewhilefocused2h3",
+      "26-30% chance to deal double damage while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "7-9% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "display": "7-9% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ChanceToDealDoubleDamageWhileFocused1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2chancetodealdoubledamagewhilefocused1h1",
+      "7-9% chance to deal double damage while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "10-12% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "display": "10-12% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ChanceToDealDoubleDamageWhileFocused1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2chancetodealdoubledamagewhilefocused1h2",
+      "10-12% chance to deal double damage while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "13-15% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "display": "13-15% chance to deal Double Damage while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ChanceToDealDoubleDamageWhileFocused1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2chancetodealdoubledamagewhilefocused1h3",
+      "13-15% chance to deal double damage while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "22-25% increased Attack and Cast Speed while Focused; grant_focus_skill 1",
+    "display": "22-25% increased Attack and Cast Speed while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2AttackAndCastSpeedWhileFocused1",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2attackandcastspeedwhilefocused1",
+      "22-25% increased attack and cast speed while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "26-30% increased Attack and Cast Speed while Focused; grant_focus_skill 1",
+    "display": "26-30% increased Attack and Cast Speed while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2AttackAndCastSpeedWhileFocused2_",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2attackandcastspeedwhilefocused2_",
+      "26-30% increased attack and cast speed while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "31-36% increased Attack and Cast Speed while Focused; grant_focus_skill 1",
+    "display": "31-36% increased Attack and Cast Speed while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2AttackAndCastSpeedWhileFocused3",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2attackandcastspeedwhilefocused3",
+      "31-36% increased attack and cast speed while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "41-50% increased Duration of Ailments you inflict while Focused; grant_focus_skill 1",
+    "display": "41-50% increased Duration of Ailments you inflict while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2StatusAilmentsYouInflictDurationWhileFocused1",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2statusailmentsyouinflictdurationwhilefocused1",
+      "41-50% increased duration of ailments you inflict while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "51-60% increased Duration of Ailments you inflict while Focused; grant_focus_skill 1",
+    "display": "51-60% increased Duration of Ailments you inflict while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2StatusAilmentsYouInflictDurationWhileFocused2",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2statusailmentsyouinflictdurationwhilefocused2",
+      "51-60% increased duration of ailments you inflict while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "61-70% increased Duration of Ailments you inflict while Focused; grant_focus_skill 1",
+    "display": "61-70% increased Duration of Ailments you inflict while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2StatusAilmentsYouInflictDurationWhileFocused3",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2statusailmentsyouinflictdurationwhilefocused3",
+      "61-70% increased duration of ailments you inflict while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "You are Immune to Ailments while Focused; grant_focus_skill 1",
+    "display": "You are Immune to Ailments while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2ImmuneToStatusAilmentsWhileFocused1",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2immunetostatusailmentswhilefocused1",
+      "you are immune to ailments while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "1000% of Damage Leeched as Life while Focused; grant_focus_skill 1; You have Vaal Pact while Focused",
+    "display": "1000% of Damage Leeched as Life while Focused; grant_focus_skill 1; You have Vaal Pact while Focused",
+    "identifier": "JunMaster2LifeLeechFromAnyDamageAndVaalPactWhileFocused1",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2lifeleechfromanydamageandvaalpactwhilefocused1",
+      "1000% of damage leeched as life while focused",
+      "grant_focus_skill 1",
+      "you have vaal pact while focused"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+25 to maximum Fortification while Focused; grant_focus_skill 1",
+    "display": "+25 to maximum Fortification while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2FortifyEffectWhileFocused1_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2fortifyeffectwhilefocused1_",
+      "+25 to maximum fortification while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+30 to maximum Fortification while Focused; grant_focus_skill 1",
+    "display": "+30 to maximum Fortification while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2FortifyEffectWhileFocused2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2fortifyeffectwhilefocused2",
+      "+30 to maximum fortification while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+35 to maximum Fortification while Focused; grant_focus_skill 1",
+    "display": "+35 to maximum Fortification while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2FortifyEffectWhileFocused3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2fortifyeffectwhilefocused3",
+      "+35 to maximum fortification while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "100% chance to Trigger Socketed Spells when you Focus, with a 0.25 second Cooldown; grant_focus_skill 1",
+    "display": "100% chance to Trigger Socketed Spells when you Focus, with a 0.25 second Cooldown; grant_focus_skill 1",
+    "identifier": "JunMaster2TriggerSocketedSpellWhenYouFocus1",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2triggersocketedspellwhenyoufocus1",
+      "100% chance to trigger socketed spells when you focus, with a 0.25 second cooldown",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-15% of Damage is taken from Mana before Life while Focused; grant_focus_skill 1",
+    "display": "11-15% of Damage is taken from Mana before Life while Focused; grant_focus_skill 1",
+    "identifier": "JunMaster2DamageRemovedFromManaBeforeLifeWhileFocused1_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2damageremovedfrommanabeforelifewhilefocused1_",
+      "11-15% of damage is taken from mana before life while focused",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Minions Recover 100% of their Life when you Focus; grant_focus_skill 1",
+    "display": "Minions Recover 100% of their Life when you Focus; grant_focus_skill 1",
+    "identifier": "JunMaster2MinionsRecoverMaximumLifeWhenYouFocus1_",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2minionsrecovermaximumlifewhenyoufocus1_",
+      "minions recover 100% of their life when you focus",
+      "grant_focus_skill 1"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "12-14% increased Damage",
+    "display": "12-14% increased Damage",
+    "identifier": "JunMaster2AllDamage2_",
+    "item_classes": [
+      "Ring",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2alldamage2_",
+      "12-14% increased damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "15-17% increased Damage",
+    "display": "15-17% increased Damage",
+    "identifier": "JunMaster2AllDamage3",
+    "item_classes": [
+      "Ring",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2alldamage3",
+      "15-17% increased damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+1 to Level of Socketed Support Gems",
+    "display": "+1 to Level of Socketed Support Gems",
+    "identifier": "JunMaster2LocalIncreaseSocketedSupportGemLevel1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasesocketedsupportgemlevel1",
+      "+1 to level of socketed support gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "+2 to Level of Socketed Support Gems",
+    "display": "+2 to Level of Socketed Support Gems",
+    "identifier": "JunMaster2LocalIncreaseSocketedSupportGemLevel2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2localincreasesocketedsupportgemlevel2",
+      "+2 to level of socketed support gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Channelling Skills have +-1 to Total Mana Cost",
+    "display": "Channelling Skills have +-1 to Total Mana Cost",
+    "identifier": "JunMaster2ReduceGlobalFlatManaCostChannelling1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2reduceglobalflatmanacostchannelling1",
+      "channelling skills have +-1 to total mana cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Channelling Skills have +-2 to Total Mana Cost",
+    "display": "Channelling Skills have +-2 to Total Mana Cost",
+    "identifier": "JunMaster2ReduceGlobalFlatManaCostChannelling2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2reduceglobalflatmanacostchannelling2",
+      "channelling skills have +-2 to total mana cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Channelling Skills have +-3 to Total Mana Cost",
+    "display": "Channelling Skills have +-3 to Total Mana Cost",
+    "identifier": "JunMaster2ReduceGlobalFlatManaCostChannelling3",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2reduceglobalflatmanacostchannelling3",
+      "channelling skills have +-3 to total mana cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Non-Channelling Skills have +-4 to Total Mana Cost",
+    "display": "Non-Channelling Skills have +-4 to Total Mana Cost",
+    "identifier": "JunMaster2ReduceGlobalFlatManaCostNonChannelling1",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2reduceglobalflatmanacostnonchannelling1",
+      "non-channelling skills have +-4 to total mana cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Non-Channelling Skills have +-5 to Total Mana Cost",
+    "display": "Non-Channelling Skills have +-5 to Total Mana Cost",
+    "identifier": "JunMaster2ReduceGlobalFlatManaCostNonChannelling2",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2reduceglobalflatmanacostnonchannelling2",
+      "non-channelling skills have +-5 to total mana cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Non-Channelling Skills have +-7--6 to Total Mana Cost",
+    "display": "Non-Channelling Skills have +-7--6 to Total Mana Cost",
+    "identifier": "JunMaster2ReduceGlobalFlatManaCostNonChannelling3",
+    "item_classes": [
+      "Ring",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2reduceglobalflatmanacostnonchannelling3",
+      "non-channelling skills have +-7--6 to total mana cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "31-36% increased Damage while Leeching",
+    "display": "31-36% increased Damage while Leeching",
+    "identifier": "JunMaster2DamageWhileLeeching2",
+    "item_classes": [
+      "Gloves",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2damagewhileleeching2",
+      "31-36% increased damage while leeching"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "37-43% increased Damage while Leeching",
+    "display": "37-43% increased Damage while Leeching",
+    "identifier": "JunMaster2DamageWhileLeeching3",
+    "item_classes": [
+      "Gloves",
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2damagewhileleeching3",
+      "37-43% increased damage while leeching"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Gemcutter's Prism"
+      }
+    ],
+    "description": "+6-7% to Quality of Socketed Gems",
+    "display": "+6-7% to Quality of Socketed Gems",
+    "identifier": "JunMaster2SocketedGemQuality2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2socketedgemquality2",
+      "+6-7% to quality of socketed gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "+7-8% to Quality of Socketed Gems",
+    "display": "+7-8% to Quality of Socketed Gems",
+    "identifier": "JunMaster2SocketedGemQuality3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2socketedgemquality3",
+      "+7-8% to quality of socketed gems"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 11-13 to 11-13 Physical Damage; Adds 16-17 to 16-17 Physical Damage; 35% chance to cause Bleeding on Hit",
+    "display": "Adds 11-13 to 11-13 Physical Damage; Adds 16-17 to 16-17 Physical Damage; 35% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2BleedOnHitGained2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2bleedonhitgained2h2",
+      "adds 11-13 to 11-13 physical damage",
+      "adds 16-17 to 16-17 physical damage",
+      "35% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 14-16 to 14-16 Physical Damage; Adds 18-20 to 18-20 Physical Damage; 40% chance to cause Bleeding on Hit",
+    "display": "Adds 14-16 to 14-16 Physical Damage; Adds 18-20 to 18-20 Physical Damage; 40% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2BleedOnHitGained2h3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2bleedonhitgained2h3_",
+      "adds 14-16 to 14-16 physical damage",
+      "adds 18-20 to 18-20 physical damage",
+      "40% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "Adds 7-8 to 7-8 Physical Damage; Adds 10-11 to 10-11 Physical Damage; 35% chance to cause Bleeding on Hit",
+    "display": "Adds 7-8 to 7-8 Physical Damage; Adds 10-11 to 10-11 Physical Damage; 35% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2BleedOnHitGained1h2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2bleedonhitgained1h2_",
+      "adds 7-8 to 7-8 physical damage",
+      "adds 10-11 to 10-11 physical damage",
+      "35% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Adds 9-11 to 9-11 Physical Damage; Adds 12-14 to 12-14 Physical Damage; 40% chance to cause Bleeding on Hit",
+    "display": "Adds 9-11 to 9-11 Physical Damage; Adds 12-14 to 12-14 Physical Damage; 40% chance to cause Bleeding on Hit",
+    "identifier": "JunMaster2BleedOnHitGained1h3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2bleedonhitgained1h3_",
+      "adds 9-11 to 9-11 physical damage",
+      "adds 12-14 to 12-14 physical damage",
+      "40% chance to cause bleeding on hit"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "Hits can't be Evaded",
+    "display": "Hits can't be Evaded",
+    "identifier": "JunMaster2AlwaysHits1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2alwayshits1",
+      "hits can't be evaded"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "19-23% increased Damage during any Flask Effect",
+    "display": "19-23% increased Damage during any Flask Effect",
+    "identifier": "JunMaster2DamageDuringFlaskEffect2_",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2damageduringflaskeffect2_",
+      "19-23% increased damage during any flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "24-28% increased Damage during any Flask Effect",
+    "display": "24-28% increased Damage during any Flask Effect",
+    "identifier": "JunMaster2DamageDuringFlaskEffect3",
+    "item_classes": [
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2damageduringflaskeffect3",
+      "24-28% increased damage during any flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Chance"
+      }
+    ],
+    "description": "36-40% increased Rarity of Items Dropped by Slain Rare or Unique Enemies",
+    "display": "36-40% increased Rarity of Items Dropped by Slain Rare or Unique Enemies",
+    "identifier": "JunMaster2ItemRarityFromRareAndUniqueEnemies2",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2itemrarityfromrareanduniqueenemies2",
+      "36-40% increased rarity of items dropped by slain rare or unique enemies"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Regal Orb"
+      }
+    ],
+    "description": "41-45% increased Rarity of Items Dropped by Slain Rare or Unique Enemies",
+    "display": "41-45% increased Rarity of Items Dropped by Slain Rare or Unique Enemies",
+    "identifier": "JunMaster2ItemRarityFromRareAndUniqueEnemies3",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2itemrarityfromrareanduniqueenemies3",
+      "41-45% increased rarity of items dropped by slain rare or unique enemies"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 11-13% of Fire Damage as Extra Chaos Damage",
+    "display": "Gain 11-13% of Fire Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2FireAddedAsChaos2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2fireaddedaschaos2h2",
+      "gain 11-13% of fire damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 14-16% of Fire Damage as Extra Chaos Damage",
+    "display": "Gain 14-16% of Fire Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2FireAddedAsChaos2h3_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2fireaddedaschaos2h3_",
+      "gain 14-16% of fire damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 5-6% of Fire Damage as Extra Chaos Damage",
+    "display": "Gain 5-6% of Fire Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2FireAddedAsChaos1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2fireaddedaschaos1h2",
+      "gain 5-6% of fire damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 7-8% of Fire Damage as Extra Chaos Damage",
+    "display": "Gain 7-8% of Fire Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2FireAddedAsChaos1h3_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2fireaddedaschaos1h3_",
+      "gain 7-8% of fire damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 11-13% of Cold Damage as Extra Chaos Damage",
+    "display": "Gain 11-13% of Cold Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2ColdAddedAsChaos2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2coldaddedaschaos2h2",
+      "gain 11-13% of cold damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 14-16% of Cold Damage as Extra Chaos Damage",
+    "display": "Gain 14-16% of Cold Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2ColdAddedAsChaos2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2coldaddedaschaos2h3",
+      "gain 14-16% of cold damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 5-6% of Cold Damage as Extra Chaos Damage",
+    "display": "Gain 5-6% of Cold Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2ColdAddedAsChaos1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2coldaddedaschaos1h2",
+      "gain 5-6% of cold damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 7-8% of Cold Damage as Extra Chaos Damage",
+    "display": "Gain 7-8% of Cold Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2ColdAddedAsChaos1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2coldaddedaschaos1h3",
+      "gain 7-8% of cold damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 11-13% of Lightning Damage as Extra Chaos Damage",
+    "display": "Gain 11-13% of Lightning Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2LightningAddedAsChaos2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2lightningaddedaschaos2h2",
+      "gain 11-13% of lightning damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 14-16% of Lightning Damage as Extra Chaos Damage",
+    "display": "Gain 14-16% of Lightning Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2LightningAddedAsChaos2h3___",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2lightningaddedaschaos2h3___",
+      "gain 14-16% of lightning damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 5-6% of Lightning Damage as Extra Chaos Damage",
+    "display": "Gain 5-6% of Lightning Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2LightningAddedAsChaos1h2__",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2lightningaddedaschaos1h2__",
+      "gain 5-6% of lightning damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 7-8% of Lightning Damage as Extra Chaos Damage",
+    "display": "Gain 7-8% of Lightning Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2LightningAddedAsChaos1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2lightningaddedaschaos1h3",
+      "gain 7-8% of lightning damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 11-13% of Physical Damage as Extra Chaos Damage",
+    "display": "Gain 11-13% of Physical Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2PhysicalAddedAsChaos2h2",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2physicaladdedaschaos2h2",
+      "gain 11-13% of physical damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 14-16% of Physical Damage as Extra Chaos Damage",
+    "display": "Gain 14-16% of Physical Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2PhysicalAddedAsChaos2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2physicaladdedaschaos2h3",
+      "gain 14-16% of physical damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 5-6% of Physical Damage as Extra Chaos Damage",
+    "display": "Gain 5-6% of Physical Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2PhysicalAddedAsChaos1h2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2physicaladdedaschaos1h2_",
+      "gain 5-6% of physical damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Vaal Orb"
+      }
+    ],
+    "description": "Gain 7-8% of Physical Damage as Extra Chaos Damage",
+    "display": "Gain 7-8% of Physical Damage as Extra Chaos Damage",
+    "identifier": "JunMaster2PhysicalAddedAsChaos1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2physicaladdedaschaos1h3",
+      "gain 7-8% of physical damage as extra chaos damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "5% increased Attributes",
+    "display": "5% increased Attributes",
+    "identifier": "JunMaster2PercentageAllAttributes2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2percentageallattributes2",
+      "5% increased attributes"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "6% increased Attributes",
+    "display": "6% increased Attributes",
+    "identifier": "JunMaster2PercentageAllAttributes3",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2percentageallattributes3",
+      "6% increased attributes"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "3-4% of Physical Damage from Hits taken as Fire Damage; 3-4% of Physical Damage from Hits taken as Lightning Damage",
+    "display": "3-4% of Physical Damage from Hits taken as Fire Damage; 3-4% of Physical Damage from Hits taken as Lightning Damage",
+    "identifier": "JunMaster2PhysicalDamageTakenAsFireAndLightningPercent1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagetakenasfireandlightningpercent1",
+      "3-4% of physical damage from hits taken as fire damage",
+      "3-4% of physical damage from hits taken as lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-6% of Physical Damage from Hits taken as Fire Damage; 5-6% of Physical Damage from Hits taken as Lightning Damage",
+    "display": "5-6% of Physical Damage from Hits taken as Fire Damage; 5-6% of Physical Damage from Hits taken as Lightning Damage",
+    "identifier": "JunMaster2PhysicalDamageTakenAsFireAndLightningPercent2",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagetakenasfireandlightningpercent2",
+      "5-6% of physical damage from hits taken as fire damage",
+      "5-6% of physical damage from hits taken as lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Trigger Level 10 Summon Spectral Wolf on Kill",
+    "display": "Trigger Level 10 Summon Spectral Wolf on Kill",
+    "identifier": "JunMaster2WolfOnKill1",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2wolfonkill1",
+      "trigger level 10 summon spectral wolf on kill"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-6% of Physical Damage from Hits taken as Fire Damage",
+    "display": "5-6% of Physical Damage from Hits taken as Fire Damage",
+    "identifier": "JunMaster2PhysicalDamageTakenAsFirePercent2_",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagetakenasfirepercent2_",
+      "5-6% of physical damage from hits taken as fire damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "7-8% of Physical Damage from Hits taken as Fire Damage",
+    "display": "7-8% of Physical Damage from Hits taken as Fire Damage",
+    "identifier": "JunMaster2PhysicalDamageTakenAsFirePercent3",
+    "item_classes": [
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2physicaldamagetakenasfirepercent3",
+      "7-8% of physical damage from hits taken as fire damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "80% chance to Avoid being Frozen",
+    "display": "80% chance to Avoid being Frozen",
+    "identifier": "JunMaster2AvoidFreeze2_",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2avoidfreeze2_",
+      "80% chance to avoid being frozen"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "100% chance to Avoid being Frozen",
+    "display": "100% chance to Avoid being Frozen",
+    "identifier": "JunMaster2AvoidFreeze3",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2avoidfreeze3",
+      "100% chance to avoid being frozen"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+18-20% to Critical Strike Multiplier if you've Shattered an Enemy Recently; 12-13% increased Global Critical Strike Chance",
+    "display": "+18-20% to Critical Strike Multiplier if you've Shattered an Enemy Recently; 12-13% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalMultiplierOnShatter2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2criticalmultiplieronshatter2",
+      "+18-20% to critical strike multiplier if you've shattered an enemy recently",
+      "12-13% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-23% to Critical Strike Multiplier if you've Shattered an Enemy Recently; 14-16% increased Global Critical Strike Chance",
+    "display": "+21-23% to Critical Strike Multiplier if you've Shattered an Enemy Recently; 14-16% increased Global Critical Strike Chance",
+    "identifier": "JunMaster2CriticalMultiplierOnShatter3",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2criticalmultiplieronshatter3",
+      "+21-23% to critical strike multiplier if you've shattered an enemy recently",
+      "14-16% increased global critical strike chance"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "11-13% increased Chaos Damage; 11-13% increased Global Physical Damage",
+    "display": "11-13% increased Chaos Damage; 11-13% increased Global Physical Damage",
+    "identifier": "JunMaster2IncreasedChaosAndPhysicalDamage2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2increasedchaosandphysicaldamage2",
+      "11-13% increased chaos damage",
+      "11-13% increased global physical damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "14-16% increased Chaos Damage; 14-16% increased Global Physical Damage",
+    "display": "14-16% increased Chaos Damage; 14-16% increased Global Physical Damage",
+    "identifier": "JunMaster2IncreasedChaosAndPhysicalDamage3_",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2increasedchaosandphysicaldamage3_",
+      "14-16% increased chaos damage",
+      "14-16% increased global physical damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "11-13% increased Fire Damage; 11-13% increased Lightning Damage",
+    "display": "11-13% increased Fire Damage; 11-13% increased Lightning Damage",
+    "identifier": "JunMaster2IncreasedFireAndLightningDamage2",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2increasedfireandlightningdamage2",
+      "11-13% increased fire damage",
+      "11-13% increased lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "14-16% increased Fire Damage; 14-16% increased Lightning Damage",
+    "display": "14-16% increased Fire Damage; 14-16% increased Lightning Damage",
+    "identifier": "JunMaster2IncreasedFireAndLightningDamage3_",
+    "item_classes": [
+      "Ring"
+    ],
+    "keywords": [
+      "junmaster2increasedfireandlightningdamage3_",
+      "14-16% increased fire damage",
+      "14-16% increased lightning damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "Regenerate 180% of Life per second during Flask Effect",
+    "display": "Regenerate 180% of Life per second during Flask Effect",
+    "identifier": "JunMaster2LocalFlaskLifeRegenerationPerMinuteDuringFlaskEffect1_",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "junmaster2localflaskliferegenerationperminuteduringflaskeffect1_",
+      "regenerate 180% of life per second during flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "50% Chance to Avoid being Stunned during Flask Effect",
+    "display": "50% Chance to Avoid being Stunned during Flask Effect",
+    "identifier": "JunMaster2LocalFlaskAvoidStunChanceDuringFlaskEffect1",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "junmaster2localflaskavoidstunchanceduringflaskeffect1",
+      "50% chance to avoid being stunned during flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "-25--20% increased Mana Cost of Skills during Flask Effect",
+    "display": "-25--20% increased Mana Cost of Skills during Flask Effect",
+    "identifier": "JunMaster2LocalFlaskSkillManaCostDuringFlaskEffect1",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "junmaster2localflaskskillmanacostduringflaskeffect1",
+      "-25--20% increased mana cost of skills during flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "20-30% increased Rarity of Items found during Flask Effect",
+    "display": "20-30% increased Rarity of Items found during Flask Effect",
+    "identifier": "JunMaster2LocalFlaskItemFoundRarityDuringFlaskEffect1",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "junmaster2localflaskitemfoundrarityduringflaskeffect1",
+      "20-30% increased rarity of items found during flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "-55--45% increased Reflected Damage taken during Flask Effect",
+    "display": "-55--45% increased Reflected Damage taken during Flask Effect",
+    "identifier": "JunMaster2LocalFlaskReducedReflectDuringEffect",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "junmaster2localflaskreducedreflectduringeffect",
+      "-55--45% increased reflected damage taken during flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Glassblower's Bauble"
+      }
+    ],
+    "description": "1500% of Damage Taken from Hits is Leeched as Life during Flask Effect",
+    "display": "1500% of Damage Taken from Hits is Leeched as Life during Flask Effect",
+    "identifier": "JunMaster2LocalFlaskLifeLeechOnDamageTakenPermyriadDuringFlaskEffect1",
+    "item_classes": [
+      "LifeFlask",
+      "ManaFlask",
+      "HybridFlask",
+      "UtilityFlask",
+      "UtilityFlaskCritical"
+    ],
+    "keywords": [
+      "junmaster2localflasklifeleechondamagetakenpermyriadduringflaskeffect1",
+      "1500% of damage taken from hits is leeched as life during flask effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "8-10% increased Attack Speed; +15-19 to Dexterity and Intelligence",
+    "display": "8-10% increased Attack Speed; +15-19 to Dexterity and Intelligence",
+    "identifier": "JunMaster2LocalAttackSpeedDexterityIntelligence1____",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localattackspeeddexterityintelligence1____",
+      "8-10% increased attack speed",
+      "+15-19 to dexterity and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "13-16% increased Attack Speed; +20-24 to Dexterity and Intelligence",
+    "display": "13-16% increased Attack Speed; +20-24 to Dexterity and Intelligence",
+    "identifier": "JunMaster2LocalAttackSpeedDexterityIntelligence2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2localattackspeeddexterityintelligence2",
+      "13-16% increased attack speed",
+      "+20-24 to dexterity and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "15-20% increased Critical Strike Chance; +15-19 to Strength and Intelligence",
+    "display": "15-20% increased Critical Strike Chance; +15-19 to Strength and Intelligence",
+    "identifier": "JunMaster2LocalCriticalStrikeChanceStrengthIntelligence1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localcriticalstrikechancestrengthintelligence1",
+      "15-20% increased critical strike chance",
+      "+15-19 to strength and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "21-25% increased Critical Strike Chance; +20-24 to Strength and Intelligence",
+    "display": "21-25% increased Critical Strike Chance; +20-24 to Strength and Intelligence",
+    "identifier": "JunMaster2LocalCriticalStrikeChanceStrengthIntelligence2___",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localcriticalstrikechancestrengthintelligence2___",
+      "21-25% increased critical strike chance",
+      "+20-24 to strength and intelligence"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "+161-200 to Accuracy Rating; +15-19 to Strength and Dexterity",
+    "display": "+161-200 to Accuracy Rating; +15-19 to Strength and Dexterity",
+    "identifier": "JunMaster2LocalAccuracyRatingStrengthDexterity1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localaccuracyratingstrengthdexterity1",
+      "+161-200 to accuracy rating",
+      "+15-19 to strength and dexterity"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+201-250 to Accuracy Rating; +20-24 to Strength and Dexterity",
+    "display": "+201-250 to Accuracy Rating; +20-24 to Strength and Dexterity",
+    "identifier": "JunMaster2LocalAccuracyRatingStrengthDexterity2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localaccuracyratingstrengthdexterity2",
+      "+201-250 to accuracy rating",
+      "+20-24 to strength and dexterity"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "8-10% increased Attack Speed; 10% chance to Trigger Level 1 Blood Rage when you Kill an Enemy",
+    "display": "8-10% increased Attack Speed; 10% chance to Trigger Level 1 Blood Rage when you Kill an Enemy",
+    "identifier": "JunMaster2LocalAttackSpeedAndLocalDisplayTriggerLevel1BloodRageOnKillChance1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2localattackspeedandlocaldisplaytriggerlevel1bloodrageonkillchance1_",
+      "8-10% increased attack speed",
+      "10% chance to trigger level 1 blood rage when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "13-16% increased Attack Speed; 10% chance to Trigger Level 1 Blood Rage when you Kill an Enemy",
+    "display": "13-16% increased Attack Speed; 10% chance to Trigger Level 1 Blood Rage when you Kill an Enemy",
+    "identifier": "JunMaster2LocalAttackSpeedAndLocalDisplayTriggerLevel1BloodRageOnKillChance2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff"
+    ],
+    "keywords": [
+      "junmaster2localattackspeedandlocaldisplaytriggerlevel1bloodrageonkillchance2",
+      "13-16% increased attack speed",
+      "10% chance to trigger level 1 blood rage when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "12-14% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "display": "12-14% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "identifier": "JunMaster2CastSpeedAndGainArcaneSurgeOnKillChance2h1_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2castspeedandgainarcanesurgeonkillchance2h1_",
+      "12-14% increased cast speed",
+      "10% chance to gain arcane surge when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "15-18% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "display": "15-18% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "identifier": "JunMaster2CastSpeedAndGainArcaneSurgeOnKillChance2h2_",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2castspeedandgainarcanesurgeonkillchance2h2_",
+      "15-18% increased cast speed",
+      "10% chance to gain arcane surge when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "19-24% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "display": "19-24% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "identifier": "JunMaster2CastSpeedAndGainArcaneSurgeOnKillChance2h3",
+    "item_classes": [
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2castspeedandgainarcanesurgeonkillchance2h3",
+      "19-24% increased cast speed",
+      "10% chance to gain arcane surge when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alteration"
+      }
+    ],
+    "description": "8-9% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "display": "8-9% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "identifier": "JunMaster2CastSpeedAndGainArcaneSurgeOnKillChance1h1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2castspeedandgainarcanesurgeonkillchance1h1",
+      "8-9% increased cast speed",
+      "10% chance to gain arcane surge when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "10-12% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "display": "10-12% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "identifier": "JunMaster2CastSpeedAndGainArcaneSurgeOnKillChance1h2",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2castspeedandgainarcanesurgeonkillchance1h2",
+      "10-12% increased cast speed",
+      "10% chance to gain arcane surge when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "13-16% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "display": "13-16% increased Cast Speed; 10% chance to gain Arcane Surge when you Kill an Enemy",
+    "identifier": "JunMaster2CastSpeedAndGainArcaneSurgeOnKillChance1h3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand"
+    ],
+    "keywords": [
+      "junmaster2castspeedandgainarcanesurgeonkillchance1h3",
+      "13-16% increased cast speed",
+      "10% chance to gain arcane surge when you kill an enemy"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "100% chance to Trigger a Socketed Spell on Using a Skill, with a 8 second Cooldown\nSpells Triggered this way have 150% more Cost",
+    "display": "100% chance to Trigger a Socketed Spell on Using a Skill, with a 8 second Cooldown\nSpells Triggered this way have 150% more Cost",
+    "identifier": "JunMaster2TriggerSocketedSpellOnSkillUse1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Wand",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Bow"
+    ],
+    "keywords": [
+      "junmaster2triggersocketedspellonskilluse1",
+      "100% chance to trigger a socketed spell on using a skill, with a 8 second cooldown\nspells triggered this way have 150% more cost"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+9-10% to Fire and Chaos Resistances",
+    "display": "+9-10% to Fire and Chaos Resistances",
+    "identifier": "JunMaster2FireAndChaosDamageResistance1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2fireandchaosdamageresistance1_",
+      "+9-10% to fire and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+11-12% to Fire and Chaos Resistances",
+    "display": "+11-12% to Fire and Chaos Resistances",
+    "identifier": "JunMaster2FireAndChaosDamageResistance2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2fireandchaosdamageresistance2_",
+      "+11-12% to fire and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+13-15% to Fire and Chaos Resistances",
+    "display": "+13-15% to Fire and Chaos Resistances",
+    "identifier": "JunMaster2FireAndChaosDamageResistance3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2fireandchaosdamageresistance3",
+      "+13-15% to fire and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+9-10% to Lightning and Chaos Resistances",
+    "display": "+9-10% to Lightning and Chaos Resistances",
+    "identifier": "JunMaster2LightningAndChaosDamageResistance1",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2lightningandchaosdamageresistance1",
+      "+9-10% to lightning and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+11-12% to Lightning and Chaos Resistances",
+    "display": "+11-12% to Lightning and Chaos Resistances",
+    "identifier": "JunMaster2LightningAndChaosDamageResistance2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2lightningandchaosdamageresistance2_",
+      "+11-12% to lightning and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+13-15% to Lightning and Chaos Resistances",
+    "display": "+13-15% to Lightning and Chaos Resistances",
+    "identifier": "JunMaster2LightningAndChaosDamageResistance3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2lightningandchaosdamageresistance3",
+      "+13-15% to lightning and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Orb of Transmutation"
+      }
+    ],
+    "description": "+9-10% to Cold and Chaos Resistances",
+    "display": "+9-10% to Cold and Chaos Resistances",
+    "identifier": "JunMaster2ColdAndChaosDamageResistance1_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2coldandchaosdamageresistance1_",
+      "+9-10% to cold and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+11-12% to Cold and Chaos Resistances",
+    "display": "+11-12% to Cold and Chaos Resistances",
+    "identifier": "JunMaster2ColdAndChaosDamageResistance2_",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2coldandchaosdamageresistance2_",
+      "+11-12% to cold and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+13-15% to Cold and Chaos Resistances",
+    "display": "+13-15% to Cold and Chaos Resistances",
+    "identifier": "JunMaster2ColdAndChaosDamageResistance3",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "junmaster2coldandchaosdamageresistance3",
+      "+13-15% to cold and chaos resistances"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Armourer's Scrap"
+      }
+    ],
+    "description": "+10-15 to Strength; 21-25% chance to Avoid being Ignited",
+    "display": "+10-15 to Strength; 21-25% chance to Avoid being Ignited",
+    "identifier": "JunMaster2StrengthAndAvoidIgnite1",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2strengthandavoidignite1",
+      "+10-15 to strength",
+      "21-25% chance to avoid being ignited"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-20 to Strength; 21-25% chance to Avoid being Ignited",
+    "display": "+16-20 to Strength; 21-25% chance to Avoid being Ignited",
+    "identifier": "JunMaster2StrengthAndAvoidIgnite2_",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2strengthandavoidignite2_",
+      "+16-20 to strength",
+      "21-25% chance to avoid being ignited"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-25 to Strength; 21-25% chance to Avoid being Ignited",
+    "display": "+21-25 to Strength; 21-25% chance to Avoid being Ignited",
+    "identifier": "JunMaster2StrengthAndAvoidIgnite3_",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2strengthandavoidignite3_",
+      "+21-25 to strength",
+      "21-25% chance to avoid being ignited"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Armourer's Scrap"
+      }
+    ],
+    "description": "+10-15 to Dexterity; 21-25% chance to Avoid being Frozen",
+    "display": "+10-15 to Dexterity; 21-25% chance to Avoid being Frozen",
+    "identifier": "JunMaster2DexterityAndAvoidFreeze1",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2dexterityandavoidfreeze1",
+      "+10-15 to dexterity",
+      "21-25% chance to avoid being frozen"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-20 to Dexterity; 21-25% chance to Avoid being Frozen",
+    "display": "+16-20 to Dexterity; 21-25% chance to Avoid being Frozen",
+    "identifier": "JunMaster2DexterityAndAvoidFreeze2___",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2dexterityandavoidfreeze2___",
+      "+16-20 to dexterity",
+      "21-25% chance to avoid being frozen"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-25 to Dexterity; 21-25% chance to Avoid being Frozen",
+    "display": "+21-25 to Dexterity; 21-25% chance to Avoid being Frozen",
+    "identifier": "JunMaster2DexterityAndAvoidFreeze3",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2dexterityandavoidfreeze3",
+      "+21-25 to dexterity",
+      "21-25% chance to avoid being frozen"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 8,
+        "currency": "Armourer's Scrap"
+      }
+    ],
+    "description": "+10-15 to Intelligence; 21-25% chance to Avoid being Shocked",
+    "display": "+10-15 to Intelligence; 21-25% chance to Avoid being Shocked",
+    "identifier": "JunMaster2IntelligenceAndAvoidShock1",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2intelligenceandavoidshock1",
+      "+10-15 to intelligence",
+      "21-25% chance to avoid being shocked"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "+16-20 to Intelligence; 21-25% chance to Avoid being Shocked",
+    "display": "+16-20 to Intelligence; 21-25% chance to Avoid being Shocked",
+    "identifier": "JunMaster2IntelligenceAndAvoidShock2",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2intelligenceandavoidshock2",
+      "+16-20 to intelligence",
+      "21-25% chance to avoid being shocked"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "+21-25 to Intelligence; 21-25% chance to Avoid being Shocked",
+    "display": "+21-25 to Intelligence; 21-25% chance to Avoid being Shocked",
+    "identifier": "JunMaster2IntelligenceAndAvoidShock3____",
+    "item_classes": [
+      "Body Armour",
+      "Shield"
+    ],
+    "keywords": [
+      "junmaster2intelligenceandavoidshock3____",
+      "+21-25 to intelligence",
+      "21-25% chance to avoid being shocked"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "7-8% increased Trap Throwing Speed",
+    "display": "7-8% increased Trap Throwing Speed",
+    "identifier": "JunMaster2TrapThrowSpeed1",
+    "item_classes": [
+      "Amulet",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2trapthrowspeed1",
+      "7-8% increased trap throwing speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-10% increased Trap Throwing Speed",
+    "display": "9-10% increased Trap Throwing Speed",
+    "identifier": "JunMaster2TrapThrowSpeed2_",
+    "item_classes": [
+      "Amulet",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2trapthrowspeed2_",
+      "9-10% increased trap throwing speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-12% increased Trap Throwing Speed",
+    "display": "11-12% increased Trap Throwing Speed",
+    "identifier": "JunMaster2TrapThrowSpeed3",
+    "item_classes": [
+      "Amulet",
+      "Belt"
+    ],
+    "keywords": [
+      "junmaster2trapthrowspeed3",
+      "11-12% increased trap throwing speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "7-8% increased Mine Throwing Speed",
+    "display": "7-8% increased Mine Throwing Speed",
+    "identifier": "JunMaster2MineLayingSpeed1",
+    "item_classes": [
+      "Amulet",
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2minelayingspeed1",
+      "7-8% increased mine throwing speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-10% increased Mine Throwing Speed",
+    "display": "9-10% increased Mine Throwing Speed",
+    "identifier": "JunMaster2MineLayingSpeed2",
+    "item_classes": [
+      "Amulet",
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2minelayingspeed2",
+      "9-10% increased mine throwing speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-12% increased Mine Throwing Speed",
+    "display": "11-12% increased Mine Throwing Speed",
+    "identifier": "JunMaster2MineLayingSpeed3",
+    "item_classes": [
+      "Amulet",
+      "Helmet"
+    ],
+    "keywords": [
+      "junmaster2minelayingspeed3",
+      "11-12% increased mine throwing speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Augmentation"
+      }
+    ],
+    "description": "11-13% increased Brand Attachment range",
+    "display": "11-13% increased Brand Attachment range",
+    "identifier": "JunMaster2BrandAttachmentRange1",
+    "item_classes": [
+      "Amulet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2brandattachmentrange1",
+      "11-13% increased brand attachment range"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "14-16% increased Brand Attachment range",
+    "display": "14-16% increased Brand Attachment range",
+    "identifier": "JunMaster2BrandAttachmentRange2_",
+    "item_classes": [
+      "Amulet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2brandattachmentrange2_",
+      "14-16% increased brand attachment range"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "17-20% increased Brand Attachment range",
+    "display": "17-20% increased Brand Attachment range",
+    "identifier": "JunMaster2BrandAttachmentRange3_",
+    "item_classes": [
+      "Amulet",
+      "Gloves"
+    ],
+    "keywords": [
+      "junmaster2brandattachmentrange3_",
+      "17-20% increased brand attachment range"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-8% increased maximum Life; 5-8% increased maximum Mana",
+    "display": "5-8% increased maximum Life; 5-8% increased maximum Mana",
+    "identifier": "JunMaster2PercentageLifeAndMana1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2percentagelifeandmana1",
+      "5-8% increased maximum life",
+      "5-8% increased maximum mana"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "5-7% Chance to Block Attack Damage",
+    "display": "5-7% Chance to Block Attack Damage",
+    "identifier": "JunMaster2BlockPercent1",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2blockpercent1",
+      "5-7% chance to block attack damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 4,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "6-8% Chance to Block Spell Damage",
+    "display": "6-8% Chance to Block Spell Damage",
+    "identifier": "JunMaster2SpellBlockPercent1_",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2spellblockpercent1_",
+      "6-8% chance to block spell damage"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 6,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "20-25% chance to Avoid Elemental Ailments; 20-25% chance to Avoid being Stunned",
+    "display": "20-25% chance to Avoid Elemental Ailments; 20-25% chance to Avoid being Stunned",
+    "identifier": "JunMaster2AvoidStunAndElementalStatusAilments1__",
+    "item_classes": [
+      "Body Armour"
+    ],
+    "keywords": [
+      "junmaster2avoidstunandelementalstatusailments1__",
+      "20-25% chance to avoid elemental ailments",
+      "20-25% chance to avoid being stunned"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-10% increased Area Damage; 6-7% increased Area of Effect",
+    "display": "9-10% increased Area Damage; 6-7% increased Area of Effect",
+    "identifier": "JunMaster2AreaDamageAndAreaOfEffect1",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2areadamageandareaofeffect1",
+      "9-10% increased area damage",
+      "6-7% increased area of effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-13% increased Area Damage; 8-9% increased Area of Effect",
+    "display": "11-13% increased Area Damage; 8-9% increased Area of Effect",
+    "identifier": "JunMaster2AreaDamageAndAreaOfEffect2_",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2areadamageandareaofeffect2_",
+      "11-13% increased area damage",
+      "8-9% increased area of effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "14-16% increased Area Damage; 10-12% increased Area of Effect",
+    "display": "14-16% increased Area Damage; 10-12% increased Area of Effect",
+    "identifier": "JunMaster2AreaDamageAndAreaOfEffect3",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2areadamageandareaofeffect3",
+      "14-16% increased area damage",
+      "10-12% increased area of effect"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-10% increased Projectile Damage; 10-12% increased Projectile Speed",
+    "display": "9-10% increased Projectile Damage; 10-12% increased Projectile Speed",
+    "identifier": "JunMaster2ProjectileDamageAndProjectileSpeed1_",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2projectiledamageandprojectilespeed1_",
+      "9-10% increased projectile damage",
+      "10-12% increased projectile speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-13% increased Projectile Damage; 13-16% increased Projectile Speed",
+    "display": "11-13% increased Projectile Damage; 13-16% increased Projectile Speed",
+    "identifier": "JunMaster2ProjectileDamageAndProjectileSpeed2_",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2projectiledamageandprojectilespeed2_",
+      "11-13% increased projectile damage",
+      "13-16% increased projectile speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "14-16% increased Projectile Damage; 17-20% increased Projectile Speed",
+    "display": "14-16% increased Projectile Damage; 17-20% increased Projectile Speed",
+    "identifier": "JunMaster2ProjectileDamageAndProjectileSpeed3",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2projectiledamageandprojectilespeed3",
+      "14-16% increased projectile damage",
+      "17-20% increased projectile speed"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 1,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Orb of Alchemy"
+      }
+    ],
+    "description": "9-10% increased Melee Damage; +1 to Melee Strike Range",
+    "display": "9-10% increased Melee Damage; +1 to Melee Strike Range",
+    "identifier": "JunMaster2MeleeDamageAndMeleeRange1",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2meleedamageandmeleerange1",
+      "9-10% increased melee damage",
+      "+1 to melee strike range"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 2,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "11-13% increased Melee Damage; +1 to Melee Strike Range",
+    "display": "11-13% increased Melee Damage; +1 to Melee Strike Range",
+    "identifier": "JunMaster2MeleeDamageAndMeleeRange2_",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2meleedamageandmeleerange2_",
+      "11-13% increased melee damage",
+      "+1 to melee strike range"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 3,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Exalted Orb"
+      }
+    ],
+    "description": "14-16% increased Melee Damage; +1 to Melee Strike Range",
+    "display": "14-16% increased Melee Damage; +1 to Melee Strike Range",
+    "identifier": "JunMaster2MeleeDamageAndMeleeRange3_",
+    "item_classes": [
+      "Amulet"
+    ],
+    "keywords": [
+      "junmaster2meleedamageandmeleerange3_",
+      "14-16% increased melee damage",
+      "+1 to melee strike range"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 3,
+        "currency": "Chaos Orb"
+      }
+    ],
+    "description": "Focus has 21-25% increased Cooldown Recovery Rate",
+    "display": "Focus has 21-25% increased Cooldown Recovery Rate",
+    "identifier": "JunMaster2FocusCooldownRecovery1_",
+    "item_classes": [
+      "Boots"
+    ],
+    "keywords": [
+      "junmaster2focuscooldownrecovery1_",
+      "focus has 21-25% increased cooldown recovery rate"
+    ],
+    "master": "Sister Cassia"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Divine Orb"
+      }
+    ],
+    "description": "Prefixes Cannot Be Changed",
+    "display": "Prefixes Cannot Be Changed",
+    "identifier": "StrMasterItemGenerationCannotChangePrefixes",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "strmasteritemgenerationcannotchangeprefixes",
+      "prefixes cannot be changed"
+    ],
+    "master": "Einhar, Beastmaster"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Divine Orb"
+      }
+    ],
+    "description": "Suffixes Cannot Be Changed",
+    "display": "Suffixes Cannot Be Changed",
+    "identifier": "DexMasterItemGenerationCannotChangeSuffixes",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "dexmasteritemgenerationcannotchangesuffixes",
+      "suffixes cannot be changed"
+    ],
+    "master": "Einhar, Beastmaster"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 2,
+        "currency": "Divine Orb"
+      }
+    ],
+    "description": "Can have up to 3 Crafted Modifiers",
+    "display": "Can have up to 3 Crafted Modifiers",
+    "identifier": "StrIntMasterItemGenerationCanHaveMultipleCraftedMods",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "strintmasteritemgenerationcanhavemultiplecraftedmods",
+      "can have up to 3 crafted modifiers"
+    ],
+    "master": "Einhar, Beastmaster"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Divine Orb"
+      }
+    ],
+    "description": "Cannot roll Attack Modifiers",
+    "display": "Cannot roll Attack Modifiers",
+    "identifier": "IntMasterItemGenerationCannotRollAttackAffixes",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "intmasteritemgenerationcannotrollattackaffixes",
+      "cannot roll attack modifiers"
+    ],
+    "master": "Einhar, Beastmaster"
+  },
+  {
+    "action": "add_explicit_mod",
+    "bench_tier": 0,
+    "costs": [
+      {
+        "amount": 1,
+        "currency": "Divine Orb"
+      }
+    ],
+    "description": "Cannot roll Caster Modifiers",
+    "display": "Cannot roll Caster Modifiers",
+    "identifier": "StrDexMasterItemGenerationCannotRollCasterAffixes",
+    "item_classes": [
+      "Dagger",
+      "Rune Dagger",
+      "One Hand Axe",
+      "One Hand Mace",
+      "One Hand Sword",
+      "Claw",
+      "Sceptre",
+      "Thrusting One Hand Sword",
+      "Two Hand Axe",
+      "Two Hand Mace",
+      "Two Hand Sword",
+      "Staff",
+      "Warstaff",
+      "Wand",
+      "Bow",
+      "Body Armour",
+      "Gloves",
+      "Boots",
+      "Helmet",
+      "Shield",
+      "Ring",
+      "Amulet",
+      "Belt",
+      "Quiver"
+    ],
+    "keywords": [
+      "strdexmasteritemgenerationcannotrollcasteraffixes",
+      "cannot roll caster modifiers"
+    ],
+    "master": "Einhar, Beastmaster"
+  }
+]

--- a/data/bosses.json
+++ b/data/bosses.json
@@ -1,0 +1,1583 @@
+{
+  "atlas_bosses": [
+    {
+      "aliases": [
+        "maven",
+        "maven's crucible"
+      ],
+      "encounter": "Maven's Crucible",
+      "name": "The Maven",
+      "notes": [
+        "Chilling Orbs: Casts several orb that when triggered, explodes and drops  which deals cold damage over time",
+        "==Drops=="
+      ],
+      "unlock": [
+        "The Maven is an NPC and boss encountered within maps. Progressing the Maven's questline allows the player to unlock the Maven's Beacon, which lets the player call upon the Maven to the map to witness you. Defeating enough unique bosses while the Maven is witnessing you will earn you a Maven's Invitation to challenge them all at once for rewards. Completing each Invitation for the first time earns you an atlas passive skill point.",
+        "The Maven can also be fought as a boss after collecting enough Crescent Splinters from challenging Invitations to form . Defeating the Maven for the first time will reward the player with an Atlas Book of Skill and a .",
+        "Activate the Maven's Beacon on your map device to call upon the Maven to the map. She will appear when you fight the map boss, empowering it in various ways. Once defeated, the boss will be marked as being witnessed by the Maven.",
+        "The Maven cannot be called to maps if she has already witnessed the boss, until you encounter them in a Maven's Invitation. To know if the map is eligible to have Maven's presence, you can check if her symbol is highlighted before activating your map device.",
+        "Maven-witnessed bosses have a chance to drop Maven's Chisels and certain awakened support gems.",
+        "By slaying 3 map bosses in the Maven's presence, you'll earn an invitation to The Maven's Crucible where she will request that you defeat these bosses simultaneously. Having demonstrated your strength, she challenges you to defeat four bosses, then five, then six and finally ten at the same time. Only then can you take on the new pinnacle boss of the Atlas: the Maven herself. The Atlas Quick Guide takes the player through all the steps required to find The Maven and to unlock The Maven's Crucible.",
+        "Players must use the  with the map device to fight the Maven.  The writ can be formed by collecting  from fights within The Maven's Crucible.",
+        "Brain Blast: \"\"/\"\"/\"\" - charges up an arena-wide explosion; the player must move to one of the two smaller platforms that are now accessible on the edges of the arena. Explodes with the line \"Space aligns.\" Removes all remaining Volatile Orbs. Deals 3 extremely high physical damage hits converted to each element, always inflicting Ignite/Shock/Freeze, and bypasses all Block or Dodge chance."
+      ]
+    },
+    {
+      "aliases": [
+        "sirus",
+        "awakener"
+      ],
+      "encounter": "Eye of the Storm",
+      "name": "Sirus, Awakener of Worlds",
+      "notes": [
+        "Sirus has various exclusive and high-value drops such as the  used for end-game crafting, and Thread of Hope, a jewel which allows allocating unconnected passives from a long distance.",
+        "==Drops==",
+        "| Encounter-<br>specific<br>drops"
+      ],
+      "unlock": [
+        "Sirus can be fought at the Eye of the Storm, accessed by using the Crest of the Elderslayers fragments in the map device. Acquired by defeating and obtaining each conqueror map fragment.",
+        "{{Mbox|text= Estimated drop rates from version 3.26.0. n=308<sup>u</sup><ref>Prohibited Library <sup>(requires membership to view)</sup> - https://discord.com/channels/991073626721763429/991092770959675412/1395746597584896062<br>https://discord.com/channels/991073626721763429/991092770959675412/1398850275317518458<br>https://discord.com/channels/991073626721763429/991092770959675412/1402449800426815641</ref> Actual drop rates may vary.<br>",
+        "The Cosmic Wounds, Memento Mori, Thirst for Knowledge, Insatiable Appetite, Throw the Gauntlet, and The Perfect Storm Atlas Keystone Passives have been removed. Instead, we have added a new set of fragments that can be used to access the Uber Pinnacle Bosses."
+      ]
+    },
+    {
+      "aliases": [
+        "shaper"
+      ],
+      "encounter": "The Shaper's Realm",
+      "name": "The Shaper",
+      "notes": [
+        "==Drops==",
+        "| Encounter-<br>specific<br>drops"
+      ],
+      "unlock": [
+        "The Shaper is one of the bosses of the Atlas end game system. He is a pinnacle boss in the the Shaper's Realm. The Shaper also occasionally appears in Shaper-influenced maps. Players can fight the Shaper using the Key to the Crucible map fragment set. These map fragments can be obtained by defeating the Guardians of the Void.",
+        "Defeating the Shaper is guaranteed to drop a map fragment required for the Uber Elder encounter, either  or . The other 2 fragments are dropped by The Elder.",
+        "Players must use the Key to the Crucible fragments in their map device to fight The Shaper. They can be collected by fighting various bosses, and can also be traded amongst players.",
+        "{{Mbox|text= Estimated drop rates from version 3.26.0. n=752<sup>u</sup><ref>https://www.reddit.com/r/pathofexile/comments/1ll4146/loot_from_250_uber_shapers/</ref><ref>https://www.reddit.com/r/pathofexile/comments/1m5ueyk/loot_form_102_uber_shaper_runs/</ref><ref>Prohibited Library <sup>(requires membership to view)</sup> - https://discord.com/channels/991073626721763429/991092770959675412/1394962171863236748<br>https://discord.com/channels/991073626721763429/991092770959675412/1396778989166530660<br>https://discord.com/channels/991073626721763429/991092770959675412/1398760385200263310</ref> Actual drop rates may vary.<br>"
+      ]
+    },
+    {
+      "aliases": [
+        "elder"
+      ],
+      "encounter": "The Elder",
+      "name": "The Elder",
+      "notes": [
+        "==Drops==",
+        "Always drops one of the two:",
+        "Always drops one of the following:"
+      ],
+      "unlock": [
+        "Defeating the Elder is guaranteed to drop a map fragment required for the Uber Elder encounter, either  or . The other 2 fragments are dropped by The Shaper.",
+        "Players must use the Key to Decay fragments in their map device to fight The Elder. These fragments drop from the Elder Guardians, or rarely from Fragment rewards, and they can also be traded amongst players.",
+        "The Elder is a boss that is invading the Atlas of Worlds. It was the main antagonist of the War for the Atlas expansion, where it would take over maps of the Atlas. As of the Conquerors of the Atlas expansion, as part of the canonization of the defeat of the Elder, it no longer actively interacts with the Atlas. The player characters who fought during the War for the Atlas expansion are represented by the Elderslayers led by Sirus, Awakener of Worlds.<ref>https://www.pathofexile.com/forum/view-thread/2912852</ref> Players can still fight the Elder aka Red (map) Elder, using the Key to Decay map fragments set, and do not need to chase the Elder and Shaper across the Atlas anymore. While the Yellow map Elder which has a lower area level is not in-game anymore. These map fragments can be obtained by defeating the Elder Guardians. Like other fragment bosses, the fight in the current Siege of the Atlas expansion is re-enactment of the fight as memories, rather than occurring in real-time in-universe. <ref>Based on Commander Kirac's dialogue on opening Elder Guardian Map as his atlas mission as well as the quest </ref>"
+      ]
+    },
+    {
+      "aliases": [
+        "uber elder"
+      ],
+      "encounter": "Uber Elder",
+      "name": "The Uber Elder",
+      "notes": [],
+      "unlock": []
+    },
+    {
+      "aliases": [
+        "eater"
+      ],
+      "encounter": "Absence of Symmetry and Harmony",
+      "name": "The Eater of Worlds",
+      "notes": [
+        "}}The Eater of Worlds is one of the Eldritch Horrors. Defeating The Eater of Worlds for the first time drops a  that can be socketed into the Atlas.",
+        "==Drops=="
+      ],
+      "unlock": [
+        "Players must use the  in their map device to fight The Eater of Worlds.  The invitation drops after defeating The Infinite Hunger and following the quest steps.",
+        "Avoid rolling the  invitation mod, as the boss will recharge to full Energy Shield if not actively taking damage for some time, or during immunity phases such as the Doom Phase. This mod will significantly increase the effective health of the boss and is not recommended for builds with low damage.",
+        "<ref>https://www.reddit.com/r/pathofexile/comments/1eonkdp/455_uber_eater_fragments_91_uber_eaters_again/</ref>"
+      ]
+    },
+    {
+      "aliases": [
+        "exarch",
+        "searing exarch"
+      ],
+      "encounter": "Absence of Patience and Wisdom",
+      "name": "The Searing Exarch",
+      "notes": [
+        "==Drops==",
+        "| Encounter-<br>specific<br>drops"
+      ],
+      "unlock": [
+        "Players must use the  in their map device to fight Searing Exarch.  The invitation drops after defeating The Black Star and following the quest steps.",
+        "Avoid rolling the  invitation mod, as the boss will recharge to full Energy Shield if the player fails to consecutively hit the boss or during immunity phases such as the Rolling Meteor Wall Phase. This mod will significantly increase the effective health of the boss and is not recommended for builds with low damage.",
+        "{{Mbox|text= Estimated drop rates from version 3.26.0. n=196<sup>r</sup><ref>Prohibited Library <sup>(requires membership to view)</sup> - https://discord.com/channels/991073626721763429/991092770959675412/1391076418951184495</ref>/650<sup>u</sup><ref>https://www.reddit.com/r/pathofexile/comments/1m4uggl/250_uber_exarch_results_cost_416_div/</ref><ref>https://www.reddit.com/r/pathofexile/comments/1mtsf7n/i_ran_300_uber_exarchs_so_you_dont_have_to/</ref><ref>Prohibited Library <sup>(requires membership to view)</sup> - https://discord.com/channels/991073626721763429/991092770959675412/1398760612200448070</ref>Actual drop rates may vary.<br>"
+      ]
+    }
+  ],
+  "map_bosses": [
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Acton's Nightmare",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Winterfang",
+        "Arctic Breath",
+        "Storm Eye",
+        "Solus, Pack Alpha"
+      ],
+      "map": "Caer Blaidd, Wolfpack's Den",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Avatar of Ash",
+        "Avatar of Winter",
+        "Avatar of Silence",
+        "Avatar of Apocalypse"
+      ],
+      "map": "Death and Taxes",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Vaal Oversoul"
+      ],
+      "map": "Doryani's Machinarium",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Hall of Grandmasters",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Maker of Mires",
+        "Brutus, Lord Incarcerator",
+        "Jaesyn",
+        "Hillock",
+        "Nightwane",
+        "Jik'shah",
+        "Vaal Oversoul",
+        "Modifier:MonsterAuraSpeedUniqueMap1|a hidden mod",
+        "Monster:Metadata/Monsters/IncaShadowBoss/BossIncaShadowUniqueMap",
+        "Balah, Duke",
+        "The Weaver",
+        "Tarred Ground",
+        "Kruug, the Frayed",
+        "Fidelitas, the Mourning",
+        "Grinning Totem"
+      ],
+      "map": "Hallowed Ground",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Harbinger",
+        "King Harbinger",
+        "Harbinger Scroll"
+      ],
+      "map": "Infused Beachhead",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Merveil, the Reflection",
+        "Merveil, the Returned"
+      ],
+      "map": "Maelström of Chaos",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Fairgraves, Never Dying",
+        "Movement Speed",
+        "Attack Speed"
+      ],
+      "map": "Mao Kun",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Nightmare of the Depraved Trinity",
+        "The Depraved Trinity",
+        "The Rotting Core",
+        "He of Many Pieces",
+        "Maligaro the Mutilator",
+        "Liantra",
+        "Shavronne the Sickening",
+        "Portentia, the Foul",
+        "Doedre the Defiler",
+        "Amalgam of Nightmares",
+        "Effluent",
+        "action speed|slower"
+      ],
+      "map": "Abomination Map",
+      "tier": 17,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Arbiter of Knowledge",
+        "Trinian, Intellectus Prime",
+        "The Archives",
+        "Act 3",
+        "curses"
+      ],
+      "map": "Academy Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Warband",
+        "Rama, The Kinslayer",
+        "Kalria, The Fallen",
+        "Kalria, The Risen",
+        "Invari, The Bloodshaper",
+        "Lokan, The Deceiver",
+        "Marchak, The Betrayer",
+        "Berrots, The Breaker",
+        "Vessider, The Unrivaled",
+        "Morgrants, The Deafening"
+      ],
+      "map": "Acid Caverns Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Calderus"
+      ],
+      "map": "Alleyways Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Legius Garhall",
+        "Captain Arteri",
+        "Blackguard",
+        "Cleave",
+        "Double Strike",
+        "Leap Slam"
+      ],
+      "map": "Ancient City Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Hybrid Widow",
+        "Black Death"
+      ],
+      "map": "Arachnid Tomb Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Solaris Temple Level 1|Solaris Temple",
+        "Herald of Ashes",
+        "Flame Sentinel",
+        "Firestorm",
+        "Flammability",
+        "Herald of Thunder (unique monster)|Herald of Thunder",
+        "Galvanic Ribbon",
+        "Arc",
+        "Shock Nova",
+        "Conductivity"
+      ],
+      "map": "Arcade Map",
+      "tier": 11,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Drought-Maddened Rhoa"
+      ],
+      "map": "Arid Lake Map",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Warmonger",
+        "General Gravicius"
+      ],
+      "map": "Armoury Map",
+      "tier": 13,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Steel Soul",
+        "Animated Weapon"
+      ],
+      "map": "Arsenal Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Lord of the Ashen Arrow",
+        "bandit",
+        "Blast Rain",
+        "Flame Dash",
+        "Flame Surge",
+        "Vaal Burning Arrow"
+      ],
+      "map": "Ashen Wood Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Puruna, the Challenger"
+      ],
+      "map": "Atoll Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "High Templar Avarius",
+        "the Chamber of Innocence"
+      ],
+      "map": "Basilica Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Ancient Sculptor",
+        "Marceus the Hidden",
+        "Purity Restored"
+      ],
+      "map": "Bazaar Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Glace",
+        "Hailrake",
+        "The Tidal Island (Act 1)",
+        "Ice Spear",
+        "Glacial Cascade",
+        "Ice Nova",
+        "Arctic Armour"
+      ],
+      "map": "Beach Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Lord of the Grey",
+        "Kitava",
+        "Champion of the Feast",
+        "Shaman of the Feast"
+      ],
+      "map": "Belfry Map",
+      "tier": 11,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Skullbeak",
+        "Bone Rhoa|bone rhoa"
+      ],
+      "map": "Bog Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Xixic, High Necromancer",
+        "Sawbones"
+      ],
+      "map": "Bone Crypt Map",
+      "tier": 1,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Melur Thornmaul",
+        "Orvi Acidbeak",
+        "Elida Blisterclaw",
+        "harvest",
+        "Ersi, Mother of Thorns",
+        "Janaar, the Omen",
+        "Namharim, Born of Night"
+      ],
+      "map": "Bramble Valley Map",
+      "tier": 9,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Map",
+        "Stonebeak, Battle Fowl",
+        "Eyepecker",
+        "Split Arrow",
+        "Caustic Arrow",
+        "Vaal Rain of Arrows",
+        "Gnar, Eater of Carrion",
+        "Steelchaw",
+        "Counterattack|Vengeance",
+        "bleed"
+      ],
+      "map": "Canyon Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Leif, the Swift-Handed",
+        "Kraityn"
+      ],
+      "map": "Castle Ruins Map",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Erebix, Light's Bane",
+        "Gruthkul, Mother of Despair"
+      ],
+      "map": "Cemetery Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Cardinal of Fear",
+        "Cardinal Sanctus Vox"
+      ],
+      "map": "Chambers of Impurity Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Winged Death",
+        "The Hundred Foot Shadow"
+      ],
+      "map": "Channel Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Hephaeus, The Hammer",
+        "Argus"
+      ],
+      "map": "Chateau Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Uhtred, Covetous Traitor",
+        "Vorana, Last to Fall",
+        "Medved, Feller of Heroes"
+      ],
+      "map": "Citadel Map",
+      "tier": 17,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Matriarch",
+        "The Rotten Matriarch",
+        "Twisted Effigy",
+        "enrage"
+      ],
+      "map": "City Square Map",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Ara, Sister of Light",
+        "Khor, Sister of Shadows",
+        "Solaris",
+        "Lunaris",
+        "File:Solaris sniper's mark.gif|embed|left|thumb|Ara (Solaris) using her spear attack against Khor (Lunaris) affected by a player's Sniper's Mark effect"
+      ],
+      "map": "Cold River Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Tyrant (unique monster)|Tyrant",
+        "General Gravicius",
+        "Act 3"
+      ],
+      "map": "Colonnade Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Ambrius, Legion Slayer",
+        "Daresso, King of Swords",
+        "Act 4"
+      ],
+      "map": "Colosseum Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Forgotten Soldier",
+        "Hector Titucius, Eternal Servant"
+      ],
+      "map": "Conservatory Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Captain Tanner Lightfoot",
+        "Gemling Legionnaire",
+        "The Grain Gate"
+      ],
+      "map": "Coral Ruins Map",
+      "tier": 9,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Prodigy of Pain",
+        "Prodigy of Hexes",
+        "Prodigy of Darkness",
+        "Eater of Souls"
+      ],
+      "map": "Core Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Oriath's Virtue",
+        "Oriath's Vengeance",
+        "Oriath's Vigil",
+        "Imperator Stantinus Bitterblade",
+        "Draconarius Wilhelm Flamebrand",
+        "Compulsor Octavia Sparkfist",
+        "Dominus",
+        "Act 3"
+      ],
+      "map": "Courtyard Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Neglected Flame",
+        "Sirus, the Awakener",
+        "action speed"
+      ],
+      "map": "Courtyard of Wasting Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Telvar, the Inebriated",
+        "First Mate Crastus",
+        "Pirate Treasure",
+        "Guardian of the Vault"
+      ],
+      "map": "Coves Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Kadaris, Crimson Mayor"
+      ],
+      "map": "Crimson Township Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Crystal Ore Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Pagan Bishop of Agony"
+      ],
+      "map": "Cursed Crypt Map",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Cursed King (boss)|The Cursed King"
+      ],
+      "map": "Dark Forest Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Monster:Metadata/Monsters/AvariusCasticus/AvariusCasticusWickermanMap|Woad, Mockery of Man",
+        "Avarius, Reassembled",
+        "Heretical Flare",
+        "damage over time",
+        "pantheon"
+      ],
+      "map": "Defiled Cathedral Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Terror of the Infinite Drifts",
+        "Shakari, Queen of the Sands"
+      ],
+      "map": "Desert Spring Map",
+      "tier": 9,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Stalker of the Endless Dunes",
+        "Garukhan, Queen of the Winds"
+      ],
+      "map": "Dig Map",
+      "tier": 9,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Blacksmith",
+        "Hillock"
+      ],
+      "map": "Dunes Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Penitentiary Incarcerator",
+        "Brutus, Lord Incarcerator"
+      ],
+      "map": "Dungeon Map",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Engraved Ultimatum",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Sumter the Twisted"
+      ],
+      "map": "Estuary Map",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Eroding One",
+        "Stone golem (monster type)|stone golem"
+      ],
+      "map": "Flooded Mine Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Skictis, Frostkeeper",
+        "Takatax Brittlethorn",
+        "Corruptor Eedaiak"
+      ],
+      "map": "Forbidden Woods Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Guardian of the Phoenix"
+      ],
+      "map": "Forge of the Phoenix Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Unbreakable",
+        "Magnetic Storm",
+        "debuff",
+        "action speed"
+      ],
+      "map": "Fortress Map",
+      "tier": 17,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Ciergan, Shadow Alchemist"
+      ],
+      "map": "Foundry Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Captain Clayborne, The Accursed"
+      ],
+      "map": "Frozen Cabins Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Avatar of Undoing",
+        "Chaos golem (monster type)|Chaos golem"
+      ],
+      "map": "Geode Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Lady Stormflay",
+        "Whipping Miscreation"
+      ],
+      "map": "Ghetto Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Rek'tar, the Breaker"
+      ],
+      "map": "Glacier Map",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The_Restless_Shade|The Restless Shade"
+      ],
+      "map": "Grave Trough Map",
+      "tier": 11,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Void Anomaly"
+      ],
+      "map": "Grotto Map",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Harbinger Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Mutewind",
+        "Yorishi, Aurora-sage",
+        "Jeinei Yuushu",
+        "Otesha, the Giantslayer",
+        "Whirling Blades",
+        "Cold Snap|Cold snap",
+        "Icestorm"
+      ],
+      "map": "Iceberg Map",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Ivory Temple Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Queen of the Great Tangle",
+        "The Weaver",
+        "Eldritch Altar"
+      ],
+      "map": "Jungle Valley Map",
+      "tier": 11,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Riftwalker"
+      ],
+      "map": "Laboratory Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Guardian of the Hydra"
+      ],
+      "map": "Lair of the Hydra Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "File:Kitava, The Destroyer.jpg|thumb|Kitava, the Destroyer",
+        "Kitava, The Destroyer",
+        "Kitava, the Insatiable",
+        "The Feeding Trough"
+      ],
+      "map": "Lava Lake Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Mirage of Bones",
+        "Nightwane"
+      ],
+      "map": "Leyline Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "warband",
+        "Uruk Baleh",
+        "El'Abin, Bloodeater",
+        "Leli Goya, Daughter of Ash",
+        "Bin'aia, Crimson Rain"
+      ],
+      "map": "Lighthouse Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Nightmare Manifest",
+        "Piety, the Abomination",
+        "Cleave",
+        "Corrupted Blood",
+        "Ball Lightning",
+        "Floating Eye"
+      ],
+      "map": "Malformation Map",
+      "tier": 13,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Tolman, the Exhumer",
+        "Tolman",
+        "The Quay",
+        "Desecrated Ground",
+        "Undying Evangelist",
+        "Eldritch Altar"
+      ],
+      "map": "Mausoleum Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Shadow of the Vaal (unique monster)|Shadow of the Vaal",
+        "Vaal Oversoul",
+        "Act 2"
+      ],
+      "map": "Maze Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Guardian of the Minotaur",
+        "stone golem"
+      ],
+      "map": "Maze of the Minotaur Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Oak the Mighty",
+        "Oak"
+      ],
+      "map": "Mesa Map",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Shock and Horror",
+        "Amarissa, Daughter of Merveil"
+      ],
+      "map": "Mineral Pools Map",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Sebbert, Crescent's Point"
+      ],
+      "map": "Moon Temple Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "He of Many Pieces"
+      ],
+      "map": "Museum Map",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Burtok, Conjurer of Bones",
+        "Bone Roil"
+      ],
+      "map": "Necropolis Map",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Orchard Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Maligaro the Mutilator",
+        "Maligaro, The Broken"
+      ],
+      "map": "Overgrown Shrine Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "God's Chosen",
+        "The Hallowed Husk",
+        "High Templar Dominus",
+        "Dominus, Ascendant"
+      ],
+      "map": "Palace Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Suncaller Asha"
+      ],
+      "map": "Park Map",
+      "tier": 9,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Titan of the Grove",
+        "Gneiss",
+        "The Old Fields",
+        "Act 2",
+        "Allies Cannot Die"
+      ],
+      "map": "Peninsula Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Erythrophagia",
+        "Doedre Darktongue",
+        "Molten Strike"
+      ],
+      "map": "Phantasmagoria Map",
+      "tier": 9,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Ancient Architect"
+      ],
+      "map": "Pier Map",
+      "tier": 13,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Olof, Son of the Headsman",
+        "Barkhul",
+        "Daresso's Dream"
+      ],
+      "map": "Pit Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Guardian of the Chimera"
+      ],
+      "map": "Pit of the Chimera Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "totems",
+        "Puruna, the Challenger",
+        "Poporo, the Highest Spire"
+      ],
+      "map": "Plateau Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Rogue exile|rogue exiles",
+        "Torr Olgosso",
+        "Damoi Tui",
+        "Orra Greengate",
+        "Augustina Solaria",
+        "Wilorin Demontamer",
+        "Eoin Greyfur",
+        "Igna Phoenix"
+      ],
+      "map": "Precinct Map",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "High Lithomancer"
+      ],
+      "map": "Primordial Blocks Map",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Blackguard Avenger",
+        "Captain Arteri",
+        "Cleave",
+        "Double Strike",
+        "Blackguard Tempest",
+        "Blackguard Mage",
+        "Spark",
+        "Lightning Thorns",
+        "Conductivity"
+      ],
+      "map": "Promenade Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Crusher of Gladiators",
+        "Shredder of Gladiators",
+        "Bringer of Blood"
+      ],
+      "map": "Racecourse Map",
+      "tier": 5,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Reaver",
+        "Perpetus"
+      ],
+      "map": "Ramparts Map",
+      "tier": 1,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Excellis Aurafix",
+        "Caliga, Imperatrix"
+      ],
+      "map": "Residence Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Lycia, Herald of the Scourge",
+        "Beidat, Archangel of Death",
+        "return",
+        "Heretic's Ire",
+        "Nightmare of Beidat",
+        "Beidat",
+        "Eternal Scourge"
+      ],
+      "map": "Sanctuary Map",
+      "tier": 17,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Gisale, Thought Thief",
+        "Shavronne of Umbra (unique monster)|Shavronne of Umbra"
+      ],
+      "map": "Scriptorium Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Doedre the Defiler"
+      ],
+      "map": "Sepulchre Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Warband",
+        "Musky \"Two-Eyes\" Grenn",
+        "Susara, Siren of Pondium",
+        "Lussi \"Rotmother\" Roth"
+      ],
+      "map": "Shipyard Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Belcer, the Pirate Lord",
+        "Captain Fairgraves (monster)|Fairgraves",
+        "Tormented Bootlegger",
+        "Tormented Buccaneer",
+        "Tormented Spirit",
+        "Power charge|power charges",
+        "Frenzy charge|frenzy charges",
+        "Pirate Lord's Treasure",
+        "Pirate Lord's Crewman"
+      ],
+      "map": "Shore Map",
+      "tier": 6,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Tahsin, Warmaker",
+        "Tukohama, Karui God of War"
+      ],
+      "map": "Siege Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Renkarr, The Kiln Keeper",
+        "Vilenta (monster)|Vilenta",
+        "Vilenta's Beam",
+        "Act 10"
+      ],
+      "map": "Silo Map",
+      "tier": 11,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Enticer of Rot",
+        "Alira"
+      ],
+      "map": "Spider Forest Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Strand Map",
+      "tier": 3,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Armala, the Widow",
+        "Arakaali"
+      ],
+      "map": "Sunken City Map",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Synthesised Map",
+      "tier": 11,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Jorus, Sky's Edge",
+        "Dawn, Harbinger of Solaris",
+        "Scorching Ray",
+        "Bladefall"
+      ],
+      "map": "Temple Map",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Varhesh, Shimmering Aberration"
+      ],
+      "map": "Terrace Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Shaper",
+        "The Cursed King",
+        "God's Chosen",
+        "The Hallowed Husk",
+        "Eater of Souls",
+        "Tyrant (unique monster)|Tyrant",
+        "Ambrius, Legion Slayer",
+        "The Infernal King",
+        "Piety the Empyrean",
+        "Shadow of the Vaal",
+        "Merveil, the Reflection",
+        "Merveil, the Returned",
+        "Penitentiary Incarcerator",
+        "Fire and Fury",
+        "Shock and Horror",
+        "Spinner of False Hope",
+        "Olof, Son of the Headsman",
+        "The Goddess",
+        "Nightmare Manifest",
+        "The Uncreated",
+        "The Unshaped"
+      ],
+      "map": "The Shaper's Realm",
+      "tier": 17,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Deceitful God",
+        "Innocence, God-Emperor of Eternity"
+      ],
+      "map": "Theatre of Lies Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Bazur",
+        "Liantra",
+        "Reassembled Brutus",
+        "Shavronne the Returned",
+        "Act 6"
+      ],
+      "map": "Tower Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Arachnoxia"
+      ],
+      "map": "Toxic Sewer Map",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Blood Progenitor",
+        "ape chieftain"
+      ],
+      "map": "Tropical Island Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "It That Fell",
+        "Q'uru"
+      ],
+      "map": "Underground River Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Merveil, the Reflection",
+        "Merveil, the Returned"
+      ],
+      "map": "Underground Sea Map",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Fallen Queen",
+        "The Hollow Lady",
+        "The Broken Prince",
+        "Dominus",
+        "The Upper Sceptre of God"
+      ],
+      "map": "Vaal Pyramid Map",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Atziri trio",
+        "the Apex of Sacrifice",
+        "the Alluring Abyss",
+        "Sacrifice of the Vaal",
+        "demon"
+      ],
+      "map": "Vaal Temple Map",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Guardian of the Vault"
+      ],
+      "map": "Vault Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The High Templar",
+        "Dominus",
+        "Cold Beam",
+        "Shocking Ground"
+      ],
+      "map": "Villa Map",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Portentia, the Foul",
+        "Doedre the Vile|Doedre"
+      ],
+      "map": "Waste Pool Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "The Brittle Emperor (unique monster)|The Brittle Emperor",
+        "Voll"
+      ],
+      "map": "Wasteland Map",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Fragment of Winter"
+      ],
+      "map": "Waterways Map",
+      "tier": 7,
+      "unlock": [
+        "Fragment of Winter"
+      ]
+    },
+    {
+      "bosses": [
+        "Stone of the Currents"
+      ],
+      "map": "Wharf Map",
+      "tier": 8,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Catarina, Master of Undeath",
+        "Kurgal",
+        "Ulaman",
+        "Amanamu",
+        "Evasion|Evaded",
+        "area of effect"
+      ],
+      "map": "Ziggurat Map",
+      "tier": 17,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Oba's Cursed Trove",
+      "tier": 10,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Olmec's Sanctum",
+      "tier": 1,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Talin, Faithbreaker"
+      ],
+      "map": "Pillars of Arun",
+      "tier": 2,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Mistress Hyseria"
+      ],
+      "map": "Poorjoy's Asylum",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Replica Poorjoy's Asylum",
+      "tier": 14,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "The Beachhead",
+      "tier": 15,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Infector of Dreams",
+        "Necromancer (monster type)|Necromancer",
+        "Modifier:MonsterAuraElementalDamage1|Allies deal increased Elemental Damage",
+        "Thresher",
+        "spectre",
+        "Primeval Watcher",
+        "Brittle Born-again",
+        "Rotting Damned",
+        "Frost Priest",
+        "Thunder Priest",
+        "Frost Harbinger",
+        "Flame Harbinger",
+        "item level",
+        "unique item"
+      ],
+      "map": "The Coward's Trial",
+      "tier": 7,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Headmistress Braeta"
+      ],
+      "map": "The Putrid Cloister",
+      "tier": 12,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "The Tower of Ordeals",
+      "tier": 16,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Helial, the Day Unending",
+        "Selenia, the Endless Night",
+        "Aloris, the First Light",
+        "Nebria, the Last Light",
+        "Blackguard",
+        "Solaris Concourse|Solaris",
+        "Lunaris Concourse",
+        "Opid, Helial's Herald",
+        "Arteth, Selenia's Herald",
+        "Dawn, Harbinger of Solaris|Harbingers of Solaris",
+        "Dusk, Harbinger of Lunaris|Lunaris"
+      ],
+      "map": "The Twilight Temple",
+      "tier": 4,
+      "unlock": [
+        "Completing all three fights on one side lets the player access the respective boss. If both sides are completed, the player can choose either of the bosses. The selection is triggered by standing on the relevant pressure plate (blue = Selenia, red = Helial)."
+      ]
+    },
+    {
+      "bosses": [
+        "Unknown"
+      ],
+      "map": "Vaults of Atziri",
+      "tier": 4,
+      "unlock": []
+    },
+    {
+      "bosses": [
+        "Shade of a Witch",
+        "Shade of a Duelist",
+        "Shade of a Shadow",
+        "Shade of a Marauder",
+        "Shade of a Ranger",
+        "Shade of a Scion",
+        "Shade of a Templar",
+        "Tormented Temptress",
+        "Arctic Breath"
+      ],
+      "map": "Whakawairua Tuahu",
+      "tier": 3,
+      "unlock": []
+    }
+  ]
+}

--- a/data/essences.json
+++ b/data/essences.json
@@ -1,0 +1,1472 @@
+[
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyCorruptMonolith",
+    "item_level_restriction": null,
+    "level": 0,
+    "mods": [],
+    "name": "Remnant of Corruption",
+    "spawn_level_max": 100,
+    "spawn_level_min": 32,
+    "tier": "Remnant of Corruption",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 0
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger1",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Anger",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger2",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Anger",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger3",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Anger",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger4",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Anger",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger5",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Anger",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger6",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Anger",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish1",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Anguish",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish2",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Anguish",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish3",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Anguish",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish4",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Anguish",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt1",
+    "item_level_restriction": 35,
+    "level": 1,
+    "mods": [],
+    "name": "Whispering Essence of Contempt",
+    "spawn_level_max": 47,
+    "spawn_level_min": 1,
+    "tier": "Whispering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt2",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Contempt",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt3",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Contempt",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt4",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Contempt",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt5",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Contempt",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt6",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Contempt",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt7",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Contempt",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDelirium1",
+    "item_level_restriction": null,
+    "level": 8,
+    "mods": [],
+    "name": "Essence of Delirium",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Essence of Delirium",
+    "type": {
+      "is_corruption_only": true,
+      "tier": 6
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt1",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Doubt",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt2",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Doubt",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt3",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Doubt",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt4",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Doubt",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt5",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Doubt",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDread1",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Dread",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDread2",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Dread",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceDread3",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Dread",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceEnvy1",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Envy",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceEnvy2",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Envy",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceEnvy3",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Envy",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceFear1",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Fear",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceFear2",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Fear",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceFear3",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Fear",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceFear4",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Fear",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceFear5",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Fear",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceFear6",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Fear",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed1",
+    "item_level_restriction": 35,
+    "level": 1,
+    "mods": [],
+    "name": "Whispering Essence of Greed",
+    "spawn_level_max": 47,
+    "spawn_level_min": 1,
+    "tier": "Whispering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed2",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Greed",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed3",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Greed",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed4",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Greed",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed5",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Greed",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed6",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Greed",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed7",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Greed",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred1",
+    "item_level_restriction": 35,
+    "level": 1,
+    "mods": [],
+    "name": "Whispering Essence of Hatred",
+    "spawn_level_max": 47,
+    "spawn_level_min": 1,
+    "tier": "Whispering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred2",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Hatred",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred3",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Hatred",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred4",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Hatred",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred5",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Hatred",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred6",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Hatred",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred7",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Hatred",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHorror1",
+    "item_level_restriction": null,
+    "level": 8,
+    "mods": [],
+    "name": "Essence of Horror",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Essence of Horror",
+    "type": {
+      "is_corruption_only": true,
+      "tier": 6
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceHysteria1",
+    "item_level_restriction": null,
+    "level": 8,
+    "mods": [],
+    "name": "Essence of Hysteria",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Essence of Hysteria",
+    "type": {
+      "is_corruption_only": true,
+      "tier": 6
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceInsanity1",
+    "item_level_restriction": null,
+    "level": 8,
+    "mods": [],
+    "name": "Essence of Insanity",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Essence of Insanity",
+    "type": {
+      "is_corruption_only": true,
+      "tier": 6
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing1",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Loathing",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing2",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Loathing",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing3",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Loathing",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing4",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Loathing",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceMisery1",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Misery",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceMisery2",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Misery",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceMisery3",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Misery",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceRage1",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Rage",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceRage2",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Rage",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceRage3",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Rage",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceRage4",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Rage",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceRage5",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Rage",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceScorn1",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Scorn",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceScorn2",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Scorn",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceScorn3",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Scorn",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 5
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow1",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Sorrow",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow2",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Sorrow",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow3",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Sorrow",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow4",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Sorrow",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow5",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Sorrow",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow6",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Sorrow",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite1",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Spite",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite2",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Spite",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite3",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Spite",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite4",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Spite",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering1",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Suffering",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering2",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Suffering",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering3",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Suffering",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering4",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Suffering",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering5",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Suffering",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment1",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Torment",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment2",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Torment",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment3",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Torment",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment4",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Torment",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment5",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Torment",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment6",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Torment",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 2
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe1",
+    "item_level_restriction": 35,
+    "level": 1,
+    "mods": [],
+    "name": "Whispering Essence of Woe",
+    "spawn_level_max": 47,
+    "spawn_level_min": 1,
+    "tier": "Whispering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe2",
+    "item_level_restriction": 45,
+    "level": 2,
+    "mods": [],
+    "name": "Muttering Essence of Woe",
+    "spawn_level_max": 67,
+    "spawn_level_min": 12,
+    "tier": "Muttering",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe3",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Woe",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe4",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Woe",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe5",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Woe",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe6",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Woe",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe7",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Woe",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 1
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath1",
+    "item_level_restriction": 60,
+    "level": 3,
+    "mods": [],
+    "name": "Weeping Essence of Wrath",
+    "spawn_level_max": 100,
+    "spawn_level_min": 30,
+    "tier": "Weeping",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath2",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Wrath",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath3",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Wrath",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath4",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Wrath",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath5",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Wrath",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 3
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal1",
+    "item_level_restriction": 75,
+    "level": 4,
+    "mods": [],
+    "name": "Wailing Essence of Zeal",
+    "spawn_level_max": 100,
+    "spawn_level_min": 48,
+    "tier": "Wailing",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal2",
+    "item_level_restriction": null,
+    "level": 5,
+    "mods": [],
+    "name": "Screaming Essence of Zeal",
+    "spawn_level_max": 100,
+    "spawn_level_min": 68,
+    "tier": "Screaming",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal3",
+    "item_level_restriction": null,
+    "level": 6,
+    "mods": [],
+    "name": "Shrieking Essence of Zeal",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Shrieking",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  },
+  {
+    "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal4",
+    "item_level_restriction": null,
+    "level": 7,
+    "mods": [],
+    "name": "Deafening Essence of Zeal",
+    "spawn_level_max": 0,
+    "spawn_level_min": 0,
+    "tier": "Deafening",
+    "type": {
+      "is_corruption_only": false,
+      "tier": 4
+    }
+  }
+]

--- a/data/harvest_crafts.json
+++ b/data/harvest_crafts.json
@@ -1,0 +1,416 @@
+[
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1% to Cold Resistance per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityColdResistance",
+    "item_classes": [],
+    "tags": [
+      "cold",
+      "defences",
+      "elemental",
+      "resistance"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1 to Dexterity per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityDexterity",
+    "item_classes": [],
+    "tags": [
+      "defences",
+      "attribute"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1% to Fire Resistance per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityFireResistance",
+    "item_classes": [],
+    "tags": [
+      "resistance",
+      "fire",
+      "defences",
+      "elemental"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1 to Maximum Life per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityIncreasedLife",
+    "item_classes": [],
+    "tags": [
+      "life",
+      "defences",
+      "resource"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1 to Maximum Mana per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityIncreasedMana",
+    "item_classes": [],
+    "tags": [
+      "mana",
+      "defences",
+      "resource"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1 to Intelligence per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityIntelligence_",
+    "item_classes": [],
+    "tags": [
+      "defences",
+      "attribute"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1% to Lightning Resistance per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityLightningResistance",
+    "item_classes": [],
+    "tags": [
+      "resistance",
+      "lightning",
+      "defences",
+      "elemental"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Defences",
+      "Grants +1 to Strength per 2% Quality"
+    ],
+    "groups": [
+      "AlternateArmourQuality"
+    ],
+    "identifier": "HarvestAlternateArmourQualityStrength",
+    "item_classes": [],
+    "tags": [
+      "defences",
+      "attribute"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Physical Damage",
+      "Grants 1% increased Accuracy per 2% Quality"
+    ],
+    "groups": [
+      "AlternateWeaponQuality"
+    ],
+    "identifier": "HarvestAlternateWeaponQualityAccuracyRatingIncrease_",
+    "item_classes": [],
+    "tags": [
+      "damage",
+      "attack",
+      "physical",
+      "physical_damage"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Physical Damage",
+      "Grants 1% increased Area of Effect per 4% Quality"
+    ],
+    "groups": [
+      "AlternateWeaponQuality"
+    ],
+    "identifier": "HarvestAlternateWeaponQualityAreaOfEffect_",
+    "item_classes": [],
+    "tags": [
+      "damage",
+      "attack",
+      "physical",
+      "physical_damage"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Physical Damage",
+      "Grants 1% increased Elemental Damage per 2% Quality"
+    ],
+    "groups": [
+      "AlternateWeaponQuality"
+    ],
+    "identifier": "HarvestAlternateWeaponQualityElementalDamagePercent",
+    "item_classes": [],
+    "tags": [
+      "physical_damage",
+      "damage",
+      "elemental_damage",
+      "attack",
+      "physical",
+      "elemental"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Physical Damage",
+      "1% increased Critical Strike Chance per 4% Quality"
+    ],
+    "groups": [
+      "AlternateWeaponQuality"
+    ],
+    "identifier": "HarvestAlternateWeaponQualityLocalCriticalStrikeChance__",
+    "item_classes": [],
+    "tags": [
+      "physical_damage",
+      "damage",
+      "critical",
+      "attack",
+      "physical"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Physical Damage",
+      "1% increased Attack Speed per 8% Quality"
+    ],
+    "groups": [
+      "AlternateWeaponQuality"
+    ],
+    "identifier": "HarvestAlternateWeaponQualityLocalIncreasedAttackSpeed",
+    "item_classes": [],
+    "tags": [
+      "physical_damage",
+      "damage",
+      "attack",
+      "speed",
+      "physical"
+    ]
+  },
+  {
+    "description": [
+      "Quality does not increase Physical Damage",
+      "+1 Weapon Range per 10% Quality"
+    ],
+    "groups": [
+      "AlternateWeaponQuality"
+    ],
+    "identifier": "HarvestAlternateWeaponQualityLocalMeleeWeaponRange_",
+    "item_classes": [],
+    "tags": [
+      "damage",
+      "attack",
+      "physical",
+      "physical_damage"
+    ]
+  },
+  {
+    "description": [
+      "-50% increased Charges per use"
+    ],
+    "groups": [
+      "FlaskEnchantment"
+    ],
+    "identifier": "HarvestFlaskEnchantmentChargesUsedLoweredOnUse4",
+    "item_classes": [],
+    "tags": [
+      "flask"
+    ]
+  },
+  {
+    "description": [
+      "100% increased Duration"
+    ],
+    "groups": [
+      "FlaskEnchantment"
+    ],
+    "identifier": "HarvestFlaskEnchantmentDurationLoweredOnUse1_",
+    "item_classes": [],
+    "tags": [
+      "flask"
+    ]
+  },
+  {
+    "description": [
+      "50% increased effect"
+    ],
+    "groups": [
+      "FlaskEnchantment"
+    ],
+    "identifier": "HarvestFlaskEnchantmentEffectLoweredOnUse2",
+    "item_classes": [],
+    "tags": [
+      "flask"
+    ]
+  },
+  {
+    "description": [
+      "+100 to Maximum Charges"
+    ],
+    "groups": [
+      "FlaskEnchantment"
+    ],
+    "identifier": "HarvestFlaskEnchantmentMaximumChargesLoweredOnUse3_",
+    "item_classes": [],
+    "tags": [
+      "flask"
+    ]
+  },
+  {
+    "description": [
+      "Area can contain Mysterious Harbingers",
+      "Area contains an additional Harbinger",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "HarbingerLeague"
+    ],
+    "identifier": "HarvestInfusedHarbingerLeagueCrafted",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "map_item_drop_quantity_+% 0",
+      "Area is inhabited by 12 additional Rogue Exile",
+      "map_ignore_rogue_exile_rarity_bias 1",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "MapAnarchyLeague"
+    ],
+    "identifier": "HarvestInfusedMapAnarchyExiles",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "map_item_drop_quantity_+% 0",
+      "Slaying Enemies close together can attract monsters from Beyond this realm",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "MapBeyondLeagueCrafted"
+    ],
+    "identifier": "HarvestInfusedMapBeyondLeagueCrafted",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "map_magic_pack_mod_rules 1",
+      "Area contains an additional Magic Monster pack",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "MapBloodlines"
+    ],
+    "identifier": "HarvestInfusedMapBloodlinesLeagueCrafted",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "Areas can contain Essences",
+      "Area contains an additional Essence",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "MapEssenceLeague"
+    ],
+    "identifier": "HarvestInfusedMapEssenceLeagueCrafted",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "Area contains an additional Shrine",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "AllowShrines"
+    ],
+    "identifier": "HarvestInfusedMapExtraShrinesCrafted",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "Area contains an additional Strongbox",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "StrongBoxNum"
+    ],
+    "identifier": "HarvestInfusedMapExtraStrongBoxes_",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "Area contains an additional pack with a Rare monster",
+      "map_rare_monsters_have_nemesis_mod 1",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "MapRareMonsters"
+    ],
+    "identifier": "HarvestInfusedMapNemesisZana",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "Area contains an additional Perandus Chest",
+      "Area has a 100% chance to contain Cadiro Perandus",
+      "map_extra_content_weighting 1"
+    ],
+    "groups": [
+      "MapPerandusLeague"
+    ],
+    "identifier": "HarvestInfusedMapPerandusLeagueCrafted",
+    "item_classes": [],
+    "tags": []
+  },
+  {
+    "description": [
+      "Slaying Enemies in a kill streak grants Rampage bonuses",
+      "map_item_drop_quantity_+% 20"
+    ],
+    "groups": [
+      "MapRampageLeagueCrafted"
+    ],
+    "identifier": "HarvestInfusedMapRampageLeagueCrafted",
+    "item_classes": [],
+    "tags": []
+  }
+]

--- a/poe_mcp_server/__init__.py
+++ b/poe_mcp_server/__init__.py
@@ -1,0 +1,3 @@
+"""Server utilities for Path of Exile MCP demos."""
+
+__all__ = []

--- a/poe_mcp_server/datasources/__init__.py
+++ b/poe_mcp_server/datasources/__init__.py
@@ -1,0 +1,10 @@
+"""Curated knowledge base loaders for Path of Exile data."""
+
+from . import bosses, bench_recipes, essences, harvest
+
+__all__ = [
+    "bosses",
+    "bench_recipes",
+    "essences",
+    "harvest",
+]

--- a/poe_mcp_server/datasources/bench_recipes.py
+++ b/poe_mcp_server/datasources/bench_recipes.py
@@ -1,0 +1,83 @@
+"""Load curated crafting bench recipes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Sequence
+
+from .utils import load_json
+
+
+@dataclass(frozen=True)
+class BenchCost:
+    currency: str
+    amount: int
+
+
+@dataclass(frozen=True)
+class BenchRecipe:
+    identifier: str
+    display: str
+    description: str
+    bench_tier: int
+    master: str
+    item_classes: Sequence[str]
+    action: str
+    keywords: Sequence[str]
+    costs: Sequence[BenchCost]
+
+
+class _BenchIndex:
+    def __init__(self) -> None:
+        payload = load_json("bench_recipes.json")
+        self._recipes = [
+            BenchRecipe(
+                identifier=entry["identifier"],
+                display=entry["display"],
+                description=entry["description"],
+                bench_tier=entry["bench_tier"],
+                master=entry["master"],
+                item_classes=tuple(entry.get("item_classes", [])),
+                action=entry["action"],
+                keywords=tuple(entry.get("keywords", [])),
+                costs=tuple(BenchCost(**cost) for cost in entry.get("costs", [])),
+            )
+            for entry in payload
+        ]
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        cleaned = re.sub(r"[^a-z0-9]+", " ", text.lower())
+        return " ".join(cleaned.split())
+
+    def search(self, query: str) -> List[BenchRecipe]:
+        needle = self._normalise(query)
+        matches: List[BenchRecipe] = []
+        for recipe in self._recipes:
+            haystack: Iterable[str] = [recipe.display, recipe.description, *recipe.keywords]
+            if any(needle in self._normalise(candidate) for candidate in haystack):
+                matches.append(recipe)
+        return matches
+
+    @property
+    def recipes(self) -> Sequence[BenchRecipe]:
+        return tuple(self._recipes)
+
+
+_index: _BenchIndex | None = None
+
+
+def _get_index() -> _BenchIndex:
+    global _index
+    if _index is None:
+        _index = _BenchIndex()
+    return _index
+
+
+def load() -> Sequence[BenchRecipe]:
+    return _get_index().recipes
+
+
+def find(query: str) -> Sequence[BenchRecipe]:
+    return tuple(_get_index().search(query))

--- a/poe_mcp_server/datasources/bosses.py
+++ b/poe_mcp_server/datasources/bosses.py
@@ -1,0 +1,98 @@
+"""Curated access to atlas boss metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Sequence
+
+from .utils import load_json
+
+
+@dataclass(frozen=True)
+class BossEncounter:
+    """High level encounter such as Sirus or The Maven."""
+
+    name: str
+    aliases: Sequence[str]
+    encounter: str
+    unlock: Sequence[str]
+    notes: Sequence[str]
+
+
+@dataclass(frozen=True)
+class MapBoss:
+    """Standard atlas map boss information."""
+
+    map: str
+    tier: int
+    bosses: Sequence[str]
+    unlock: Sequence[str]
+
+
+class _BossIndex:
+    def __init__(self) -> None:
+        payload = load_json("bosses.json")
+        self._atlas_bosses = [BossEncounter(**entry) for entry in payload.get("atlas_bosses", [])]
+        self._map_bosses = [MapBoss(**entry) for entry in payload.get("map_bosses", [])]
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        cleaned = re.sub(r"[^a-z0-9]+", " ", text.lower())
+        return " ".join(cleaned.split())
+
+    def _contains(self, haystack: Iterable[str], needle: str) -> bool:
+        needle_norm = self._normalise(needle)
+        for candidate in haystack:
+            if needle_norm in self._normalise(candidate):
+                return True
+        return False
+
+    def find_atlas_bosses(self, query: str) -> List[BossEncounter]:
+        return [boss for boss in self._atlas_bosses if self._contains([boss.name, *boss.aliases], query)]
+
+    def find_map_bosses(self, query: str) -> List[MapBoss]:
+        matches: List[MapBoss] = []
+        for boss in self._map_bosses:
+            haystack = [boss.map, *boss.bosses]
+            if self._contains(haystack, query):
+                matches.append(boss)
+        return matches
+
+    @property
+    def atlas_bosses(self) -> Sequence[BossEncounter]:
+        return tuple(self._atlas_bosses)
+
+    @property
+    def map_bosses(self) -> Sequence[MapBoss]:
+        return tuple(self._map_bosses)
+
+
+_index: _BossIndex | None = None
+
+
+def _get_index() -> _BossIndex:
+    global _index
+    if _index is None:
+        _index = _BossIndex()
+    return _index
+
+
+def load_atlas_bosses() -> Sequence[BossEncounter]:
+    """Return all high level boss encounters."""
+    return _get_index().atlas_bosses
+
+
+def load_map_bosses() -> Sequence[MapBoss]:
+    """Return all atlas map bosses."""
+    return _get_index().map_bosses
+
+
+def search(query: str) -> dict[str, Sequence[BossEncounter | MapBoss]]:
+    """Search both encounter lists for :data:`query`."""
+
+    index = _get_index()
+    return {
+        "atlas_bosses": index.find_atlas_bosses(query),
+        "map_bosses": index.find_map_bosses(query),
+    }

--- a/poe_mcp_server/datasources/essences.py
+++ b/poe_mcp_server/datasources/essences.py
@@ -1,0 +1,64 @@
+"""Essence metadata loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Sequence
+
+from .utils import load_json
+
+
+@dataclass(frozen=True)
+class Essence:
+    identifier: str
+    name: str
+    tier: str
+    level: int
+    type: str
+    mods: Sequence[str]
+    item_level_restriction: int | None
+    spawn_level_min: int | None
+    spawn_level_max: int | None
+
+
+class _EssenceIndex:
+    def __init__(self) -> None:
+        payload = load_json("essences.json")
+        self._entries = [Essence(**entry) for entry in payload]
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        cleaned = re.sub(r"[^a-z0-9]+", " ", text.lower())
+        return " ".join(cleaned.split())
+
+    def search(self, query: str) -> List[Essence]:
+        needle = self._normalise(query)
+        matches: List[Essence] = []
+        for essence in self._entries:
+            haystack: Iterable[str] = [essence.name, essence.type, *essence.mods]
+            if any(needle in self._normalise(candidate) for candidate in haystack):
+                matches.append(essence)
+        return matches
+
+    @property
+    def entries(self) -> Sequence[Essence]:
+        return tuple(self._entries)
+
+
+_index: _EssenceIndex | None = None
+
+
+def _get_index() -> _EssenceIndex:
+    global _index
+    if _index is None:
+        _index = _EssenceIndex()
+    return _index
+
+
+def load() -> Sequence[Essence]:
+    return _get_index().entries
+
+
+def find(query: str) -> Sequence[Essence]:
+    return tuple(_get_index().search(query))

--- a/poe_mcp_server/datasources/harvest.py
+++ b/poe_mcp_server/datasources/harvest.py
@@ -1,0 +1,60 @@
+"""Harvest craft metadata loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Sequence
+
+from .utils import load_json
+
+
+@dataclass(frozen=True)
+class HarvestCraft:
+    identifier: str
+    description: Sequence[str]
+    groups: Sequence[str]
+    tags: Sequence[str]
+    item_classes: Sequence[str]
+
+
+class _HarvestIndex:
+    def __init__(self) -> None:
+        payload = load_json("harvest_crafts.json")
+        self._entries = [HarvestCraft(**entry) for entry in payload]
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        cleaned = re.sub(r"[^a-z0-9]+", " ", text.lower())
+        return " ".join(cleaned.split())
+
+    def search(self, query: str) -> List[HarvestCraft]:
+        needle = self._normalise(query)
+        matches: List[HarvestCraft] = []
+        for craft in self._entries:
+            haystack: Iterable[str] = [*craft.description, *craft.groups, *craft.tags]
+            if any(needle in self._normalise(candidate) for candidate in haystack):
+                matches.append(craft)
+        return matches
+
+    @property
+    def entries(self) -> Sequence[HarvestCraft]:
+        return tuple(self._entries)
+
+
+_index: _HarvestIndex | None = None
+
+
+def _get_index() -> _HarvestIndex:
+    global _index
+    if _index is None:
+        _index = _HarvestIndex()
+    return _index
+
+
+def load() -> Sequence[HarvestCraft]:
+    return _get_index().entries
+
+
+def find(query: str) -> Sequence[HarvestCraft]:
+    return tuple(_get_index().search(query))

--- a/poe_mcp_server/datasources/utils.py
+++ b/poe_mcp_server/datasources/utils.py
@@ -1,0 +1,18 @@
+"""Helper functions for loading curated static data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+
+def load_json(name: str) -> Any:
+    """Load a JSON document from :mod:`data` using UTF-8 encoding."""
+    path = DATA_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(f"Expected data file {path} was not found. Run scripts/sync_static_data.py first.")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)

--- a/poe_mcp_server/models.py
+++ b/poe_mcp_server/models.py
@@ -1,0 +1,15 @@
+"""Shared data structures used by the server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class CraftingStep:
+    """A single crafting instruction augmented with metadata."""
+
+    action: str
+    instruction: str
+    metadata: Dict[str, Any] = field(default_factory=dict)

--- a/poe_mcp_server/planner.py
+++ b/poe_mcp_server/planner.py
@@ -1,0 +1,94 @@
+"""High level planner that enriches crafting steps with curated intel."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Iterable, List, Sequence
+
+from .datasources import bench_recipes, bosses, essences, harvest
+from .models import CraftingStep
+
+
+def _format_section(header: str, lines: Iterable[str]) -> str:
+    body = [line for line in lines if line]
+    if not body:
+        return ""
+    return "\n".join([header, *body])
+
+
+def _format_costs(costs: Sequence[bench_recipes.BenchCost]) -> str:
+    if not costs:
+        return "free"
+    return ", ".join(f"{cost.amount} {cost.currency}" for cost in costs)
+
+
+def assemble_crafting_plan(actions: Sequence[str]) -> List[CraftingStep]:
+    """Attach structured intel to a list of crafting actions."""
+
+    enriched_steps: List[CraftingStep] = []
+    for raw_action in actions:
+        base_text = raw_action.strip()
+        instruction_parts: List[str] = [base_text]
+        metadata: dict[str, object] = {}
+
+        boss_hits = bosses.search(base_text)
+        atlas_bosses = boss_hits.get("atlas_bosses", [])
+        map_bosses = boss_hits.get("map_bosses", [])
+        if atlas_bosses:
+            metadata["atlas_bosses"] = [asdict(boss) for boss in atlas_bosses]
+            lines = [
+                f"- {boss.name} ({boss.encounter})"
+                + (f" – Unlock: {boss.unlock[0]}" if boss.unlock else "")
+                for boss in atlas_bosses[:3]
+            ]
+            section = _format_section("Boss Intel:", lines)
+            if section:
+                instruction_parts.append(section)
+        if map_bosses:
+            metadata["map_bosses"] = [asdict(boss) for boss in map_bosses]
+            lines = [
+                f"- {boss.map} (Tier {boss.tier}) – {', '.join(boss.bosses)}"
+                + (f"; {boss.unlock[0]}" if boss.unlock else "")
+                for boss in map_bosses[:3]
+            ]
+            section = _format_section("Map Boss Details:", lines)
+            if section:
+                instruction_parts.append(section)
+
+        bench_hits = bench_recipes.find(base_text)
+        if bench_hits:
+            metadata["bench_recipes"] = [asdict(recipe) for recipe in bench_hits]
+            lines = [
+                f"- {recipe.display} ({recipe.master}, tier {recipe.bench_tier}; cost {_format_costs(recipe.costs)})"
+                for recipe in bench_hits[:3]
+            ]
+            section = _format_section("Workbench Options:", lines)
+            if section:
+                instruction_parts.append(section)
+
+        harvest_hits = harvest.find(base_text)
+        if harvest_hits:
+            metadata["harvest_crafts"] = [asdict(craft) for craft in harvest_hits]
+            lines = [
+                f"- {craft.description[0]}" + (f" [{', '.join(craft.groups)}]" if craft.groups else "")
+                for craft in harvest_hits[:3]
+            ]
+            section = _format_section("Harvest Options:", lines)
+            if section:
+                instruction_parts.append(section)
+
+        essence_hits = essences.find(base_text)
+        if essence_hits:
+            metadata["essences"] = [asdict(essence) for essence in essence_hits]
+            lines = [
+                f"- {essence.name} (Tier {essence.tier}, lvl {essence.level}) – {', '.join(essence.mods[:2])}"
+                for essence in essence_hits[:3]
+            ]
+            section = _format_section("Essence Notes:", lines)
+            if section:
+                instruction_parts.append(section)
+
+        instruction = "\n\n".join(part for part in instruction_parts if part)
+        enriched_steps.append(CraftingStep(action=base_text, instruction=instruction, metadata=metadata))
+
+    return enriched_steps

--- a/scripts/sync_static_data.py
+++ b/scripts/sync_static_data.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Download and curate static datasets for the POE MCP knowledge base."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import requests
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+HEADERS = {"User-Agent": "poe-mcp-static-sync/1.0"}
+POEWIKI_EXPORT = "https://www.poewiki.net/w/index.php"
+POEWIKI_API = "https://www.poewiki.net/w/api.php"
+REPOE_BASE = "https://raw.githubusercontent.com/brather1ng/RePoE/master/RePoE/data"
+
+LOGGER = logging.getLogger("sync_static_data")
+
+
+@dataclass
+class StatTranslation:
+    ids: Sequence[str]
+    entries: Sequence[dict]
+
+
+class StatTranslator:
+    """Convert RePoE stat definitions into human readable strings."""
+
+    def __init__(self, translations: Sequence[dict]) -> None:
+        self._multi: dict[tuple[str, ...], List[dict]] = {}
+        self._single: dict[str, List[dict]] = {}
+        for entry in translations:
+            ids = tuple(entry.get("ids", []))
+            if not ids:
+                continue
+            english_entries = entry.get("English", [])
+            if not english_entries:
+                continue
+            self._multi.setdefault(ids, []).extend(english_entries)
+            for stat_id in ids:
+                self._single.setdefault(stat_id, []).extend(english_entries)
+
+    def _format_number(self, value: float | int) -> str:
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        if isinstance(value, float):
+            text = f"{value:.2f}".rstrip("0").rstrip(".")
+            return text or "0"
+        return str(value)
+
+    def _format_value(self, stat: dict, fmt: str) -> str:
+        fmt = fmt or "#"
+        fmt_lower = fmt.lower()
+        if fmt_lower == "ignore":
+            return ""
+        min_value = stat.get("min")
+        max_value = stat.get("max")
+        if min_value is None and max_value is None:
+            value = stat.get("value", 0)
+            min_value = max_value = value
+        if min_value is None:
+            min_value = max_value
+        if max_value is None:
+            max_value = min_value
+        if min_value == max_value:
+            base = self._format_number(min_value)
+        else:
+            base = f"{self._format_number(min_value)}-{self._format_number(max_value)}"
+        prefix = ""
+        suffix = ""
+        if fmt_lower.endswith("%"):
+            suffix = "%"
+            fmt_lower = fmt_lower[:-1]
+        if fmt_lower.startswith("+"):
+            prefix = "+"
+            fmt_lower = fmt_lower[1:]
+        if fmt_lower in {"# to #", "#to#"}:
+            base = f"{self._format_number(min_value)} to {self._format_number(max_value)}"
+        return f"{prefix}{base}{suffix}".strip()
+
+    def _translate_entry(self, stats: Sequence[dict], english: dict) -> str:
+        fmt = english.get("format", [])
+        if not fmt:
+            return english.get("string", "").strip()
+        values = []
+        for index, fmt_spec in enumerate(fmt):
+            source = stats[min(index, len(stats) - 1)]
+            values.append(self._format_value(source, fmt_spec))
+        template = english.get("string", "")
+        try:
+            text = template.format(*values)
+        except Exception:  # pragma: no cover - defensive for rare translation combos
+            text = template + " " + " ".join(v for v in values if v)
+        return text.strip()
+
+    def translate(self, stats: Sequence[dict]) -> List[str]:
+        if not stats:
+            return []
+        stat_ids = tuple(stat.get("id") for stat in stats)
+        matches = self._multi.get(stat_ids)
+        if matches:
+            return [self._translate_entry(stats, matches[0])]
+        rendered: List[str] = []
+        for stat in stats:
+            options = self._single.get(stat.get("id"), [])
+            if options:
+                rendered.append(self._translate_entry([stat], options[0]))
+            else:
+                value_text = self._format_value(stat, "#")
+                rendered.append(f"{stat.get('id')} {value_text}".strip())
+        return [line for line in rendered if line]
+
+
+def fetch_json(url: str) -> object:
+    LOGGER.debug("GET %s", url)
+    response = requests.get(url, headers=HEADERS, timeout=60)
+    response.raise_for_status()
+    if response.headers.get("Content-Type", "").startswith("application/json"):
+        return response.json()
+    return json.loads(response.text)
+
+
+def ensure_data_dir() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def write_json(name: str, payload: object) -> None:
+    path = DATA_DIR / name
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+    LOGGER.info("Wrote %s", path)
+
+
+def build_translator() -> StatTranslator:
+    stats_url = f"{REPOE_BASE}/stat_translations.min.json"
+    translations = fetch_json(stats_url)
+    return StatTranslator(translations)
+
+
+def sync_bench_data(translator: StatTranslator) -> None:
+    bench_url = f"{REPOE_BASE}/crafting_bench_options.min.json"
+    mods_url = f"{REPOE_BASE}/mods.min.json"
+    base_items_url = f"{REPOE_BASE}/base_items.min.json"
+    bench_entries = fetch_json(bench_url)
+    mods = fetch_json(mods_url)
+    base_items = fetch_json(base_items_url)
+
+    colour_map = {"R": "red", "G": "green", "B": "blue", "W": "white"}
+    curated: List[dict] = []
+    for entry in bench_entries:
+        actions = entry.get("actions", {})
+        identifier = None
+        display = ""
+        keywords: List[str] = []
+        if "add_explicit_mod" in actions:
+            identifier = actions["add_explicit_mod"]
+            mod = mods.get(identifier)
+            if not mod:
+                continue
+            lines = translator.translate(mod.get("stats", []))
+            display = "; ".join(lines) or identifier
+            keywords.extend([identifier.lower(), *(line.lower() for line in lines)])
+        elif "add_enchant_mod" in actions:
+            identifier = actions["add_enchant_mod"]
+            mod = mods.get(identifier)
+            if not mod:
+                continue
+            lines = translator.translate(mod.get("stats", []))
+            display = "; ".join(lines) or identifier
+            keywords.extend([identifier.lower(), *(line.lower() for line in lines)])
+        elif "change_socket_count" in actions:
+            count = actions["change_socket_count"]
+            display = f"Set number of sockets to {count}"
+            keywords.extend(["socket", f"{count}-socket"])
+        elif "color_sockets" in actions:
+            colour = actions["color_sockets"]
+            colour_name = colour_map.get(colour, str(colour))
+            display = f"Force a {colour_name} socket"
+            keywords.extend(["colour", colour_name])
+        elif "link_sockets" in actions:
+            links = actions["link_sockets"]
+            display = f"Link {links} sockets"
+            keywords.extend(["link", f"{links}-link"])
+        elif "remove_crafted_mods" in actions:
+            display = "Remove crafted modifiers"
+            keywords.extend(["remove crafted", "craft remove"])
+        elif "remove_enchantments" in actions:
+            display = "Remove enchantments"
+            keywords.extend(["remove enchant", "enchant"])
+        else:
+            identifier = next(iter(actions.values()), None)
+            display = ", ".join(f"{key}: {value}" for key, value in actions.items())
+            keywords.extend(actions.keys())
+        if not identifier:
+            identifier = f"{entry.get('master','Unknown')}::{display}"
+
+        costs = []
+        for metadata_id, amount in entry.get("cost", {}).items():
+            base = base_items.get(metadata_id, {})
+            currency_name = base.get("name") or metadata_id.split("/")[-1]
+            costs.append({"currency": currency_name, "amount": amount})
+
+        curated.append(
+            {
+                "identifier": identifier,
+                "display": display,
+                "description": display,
+                "bench_tier": entry.get("bench_tier", 0),
+                "master": entry.get("master", "Unknown"),
+                "item_classes": entry.get("item_classes", []),
+                "action": next(iter(actions.keys()), "unknown"),
+                "keywords": keywords,
+                "costs": costs,
+            }
+        )
+
+    write_json("bench_recipes.json", curated)
+
+
+def sync_essence_data(translator: StatTranslator) -> None:
+    essences_url = f"{REPOE_BASE}/essences.min.json"
+    mods_url = f"{REPOE_BASE}/mods.min.json"
+    essences_raw = fetch_json(essences_url)
+    mods = fetch_json(mods_url)
+    curated: List[dict] = []
+    for identifier, data in essences_raw.items():
+        mod_texts: List[str] = []
+        for mod_id in data.get("mods", []):
+            mod = mods.get(mod_id)
+            if mod:
+                mod_texts.extend(translator.translate(mod.get("stats", [])))
+        tier = data.get("name", "").split(" Essence ")[0]
+        curated.append(
+            {
+                "identifier": identifier,
+                "name": data.get("name", identifier),
+                "tier": tier,
+                "level": data.get("level", 0),
+                "type": data.get("type", ""),
+                "mods": mod_texts,
+                "item_level_restriction": data.get("item_level_restriction"),
+                "spawn_level_min": data.get("spawn_level_min"),
+                "spawn_level_max": data.get("spawn_level_max"),
+            }
+        )
+    write_json("essences.json", curated)
+
+
+def clean_wiki_markup(text: str) -> str:
+    text = re.sub(r"\{\{.*?\}\}", "", text)
+    text = re.sub(r"\[\[([^\]|]+)\|([^\]]+)\]\]", r"\2", text)
+    text = re.sub(r"\[\[([^\]]+)\]\]", r"\1", text)
+    text = re.sub(r"''+", "", text)
+    text = re.sub(r"^[*#\s]+", "", text)
+    return text.strip()
+
+
+def fetch_map_rows() -> List[dict]:
+    params = {
+        "title": "Special:CargoExport",
+        "tables": "maps",
+        "fields": "maps._pageName=Map,maps.tier,maps.series",
+        "where": "maps.tier>0",
+        "limit": 500,
+        "format": "json",
+    }
+    rows: List[dict] = []
+    offset = 0
+    while True:
+        params["offset"] = offset
+        response = requests.get(POEWIKI_EXPORT, params=params, headers=HEADERS, timeout=60)
+        response.raise_for_status()
+        chunk = response.json()
+        if not chunk:
+            break
+        rows.extend(chunk)
+        if len(chunk) < params["limit"]:
+            break
+        offset += len(chunk)
+    return rows
+
+
+def fetch_wikitext(title: str) -> str | None:
+    params = {"action": "parse", "page": title, "prop": "wikitext", "format": "json"}
+    response = requests.get(POEWIKI_API, params=params, headers=HEADERS, timeout=60)
+    if response.status_code != 200:
+        return None
+    data = response.json()
+    return data.get("parse", {}).get("wikitext", {}).get("*")
+
+
+def extract_map_boss_info(title: str, tier: int) -> dict | None:
+    wikitext = fetch_wikitext(title)
+    if not wikitext:
+        return None
+    section_split = wikitext.split("==Boss==", 1)
+    bosses: List[str] = []
+    unlock: List[str] = []
+    if len(section_split) > 1:
+        boss_section = section_split[1].split("==", 1)[0]
+        for chunk in boss_section.split("[[")[1:]:
+            name = chunk.split("]]", 1)[0]
+            cleaned = clean_wiki_markup(name)
+            if cleaned:
+                bosses.append(cleaned)
+        lines = [clean_wiki_markup(line) for line in boss_section.splitlines() if line.strip()]
+        keywords = ("access", "require", "obtain", "fragment", "invitation", "witness")
+        for line in lines:
+            lower = line.lower()
+            if any(word in lower for word in keywords):
+                unlock.append(line)
+                if len(unlock) >= 2:
+                    break
+    bosses = list(dict.fromkeys(bosses))
+    return {
+        "map": title,
+        "tier": tier,
+        "bosses": bosses or ["Unknown"],
+        "unlock": unlock,
+    }
+
+
+SPECIAL_BOSSES = [
+    {"name": "The Maven", "page": "The_Maven", "encounter": "Maven's Crucible", "aliases": ["maven", "maven's crucible"]},
+    {"name": "Sirus, Awakener of Worlds", "page": "Sirus,_Awakener_of_Worlds", "encounter": "Eye of the Storm", "aliases": ["sirus", "awakener"]},
+    {"name": "The Shaper", "page": "The_Shaper", "encounter": "The Shaper's Realm", "aliases": ["shaper"]},
+    {"name": "The Elder", "page": "The_Elder", "encounter": "The Elder", "aliases": ["elder"]},
+    {"name": "The Uber Elder", "page": "The_Shaper_and_the_Elder", "encounter": "Uber Elder", "aliases": ["uber elder"]},
+    {"name": "The Eater of Worlds", "page": "The_Eater_of_Worlds", "encounter": "Absence of Symmetry and Harmony", "aliases": ["eater"]},
+    {"name": "The Searing Exarch", "page": "The_Searing_Exarch", "encounter": "Absence of Patience and Wisdom", "aliases": ["exarch", "searing exarch"]},
+]
+
+
+def extract_special_boss(entry: dict) -> dict:
+    wikitext = fetch_wikitext(entry["page"])
+    lines = []
+    notes = []
+    if wikitext:
+        raw_lines = [clean_wiki_markup(line) for line in wikitext.splitlines() if line.strip()]
+        keywords = ("access", "unlock", "requires", "fragment", "invitation", "witness", "writ", "collect")
+        for line in raw_lines:
+            lower = line.lower()
+            if any(word in lower for word in keywords):
+                lines.append(line)
+            elif "reward" in lower or "drops" in lower:
+                notes.append(line)
+            if len(lines) >= 3 and len(notes) >= 2:
+                break
+    return {
+        "name": entry["name"],
+        "aliases": entry.get("aliases", []),
+        "encounter": entry.get("encounter", entry["name"]),
+        "unlock": lines,
+        "notes": notes[:3],
+    }
+
+
+def sync_boss_data() -> None:
+    rows = fetch_map_rows()
+    curated_maps: List[dict] = []
+    chosen: dict[str, dict] = {}
+    for row in rows:
+        title = row.get("Map")
+        if not title:
+            continue
+        base_title = title
+        if base_title.startswith("Map:"):
+            base_title = base_title[4:]
+        if " (" in base_title:
+            base_title = base_title.split(" (", 1)[0]
+        if base_title.startswith("Shaped "):
+            base_title = base_title[len("Shaped "):]
+        if base_title.startswith("Elder "):
+            base_title = base_title[len("Elder "):]
+        base_title = base_title.replace("_", " ")
+        series = row.get("series", "")
+        tier = int(row.get("tier", 0))
+        if series == "Settlers" and tier < 14:
+            continue
+        if series not in {"Settlers", "Mercenaries"}:
+            continue
+        priority = 1 if series == "Settlers" else 0
+        current = chosen.get(base_title)
+        if current is None or priority > current["priority"]:
+            chosen[base_title] = {"title": base_title, "tier": tier, "priority": priority}
+    for selection in chosen.values():
+        info = extract_map_boss_info(selection["title"], selection["tier"])
+        if info:
+            curated_maps.append(info)
+    atlas_bosses = [extract_special_boss(entry) for entry in SPECIAL_BOSSES]
+    payload = {"atlas_bosses": atlas_bosses, "map_bosses": curated_maps}
+    write_json("bosses.json", payload)
+
+
+def sync_harvest_data(translator: StatTranslator) -> None:
+    mods_url = f"{REPOE_BASE}/mods.min.json"
+    mods = fetch_json(mods_url)
+    curated: List[dict] = []
+    for identifier, mod in mods.items():
+        if not identifier.lower().startswith("harvest"):
+            continue
+        description = translator.translate(mod.get("stats", [])) or [identifier]
+        curated.append(
+            {
+                "identifier": identifier,
+                "description": description,
+                "groups": mod.get("groups", []),
+                "tags": list({*mod.get("adds_tags", []), *mod.get("implicit_tags", [])}),
+                "item_classes": mod.get("item_classes", []),
+            }
+        )
+    write_json("harvest_crafts.json", curated)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sections",
+        choices=["bosses", "bench", "essences", "harvest"],
+        nargs="*",
+        help="Limit execution to selected sections.",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, format="%(message)s")
+    ensure_data_dir()
+    translator = build_translator()
+
+    sections = set(args.sections or ["bosses", "bench", "essences", "harvest"])
+    if "bench" in sections:
+        LOGGER.info("Syncing crafting bench options...")
+        sync_bench_data(translator)
+    if "essences" in sections:
+        LOGGER.info("Syncing essences...")
+        sync_essence_data(translator)
+    if "harvest" in sections:
+        LOGGER.info("Syncing Harvest crafts...")
+        sync_harvest_data(translator)
+    if "bosses" in sections:
+        LOGGER.info("Syncing boss data...")
+        sync_boss_data()
+
+    LOGGER.info("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a poe_mcp_server package that loads curated bench, essence, harvest, and boss data into the planner
- add scripts/sync_static_data.py to keep the JSON datasets fresh from PoE Wiki and RePoE exports
- refresh the README with the static data sync workflow and expectations

## Testing
- python scripts/sync_static_data.py --sections bosses

------
https://chatgpt.com/codex/tasks/task_e_68cd22a4317c833182cd72a274110181