### PR TITLE
Add PoB crafting planner heuristics and integration test

### DIFF
--- a/poe_mcp_server/datasources/essences.py
+++ b/poe_mcp_server/datasources/essences.py
@@ -29,7 +29,7 @@ class _EssenceIndex:
 
     @staticmethod
     def _normalise(text: str) -> str:
-        cleaned = re.sub(r"[^a-z0-9]+", " ", text.lower())
+        cleaned = re.sub(r"[^a-z0-9]+", " ", str(text).lower())
         return " ".join(cleaned.split())
 
     def search(self, query: str) -> List[Essence]:

--- a/poe_mcp_server/models.py
+++ b/poe_mcp_server/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Literal, Mapping, Sequence
 
 
 @dataclass
@@ -13,3 +13,54 @@ class CraftingStep:
     action: str
     instruction: str
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+ModType = Literal["prefix", "suffix", "implicit", "crafted"]
+
+
+@dataclass(frozen=True)
+class SourceHint:
+    """Optional pointer describing the expected origin of a modifier."""
+
+    kind: Literal["essence", "bench", "harvest", "influence", "other"]
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class ModRequirement:
+    """Represents a modifier that must appear on the finished item."""
+
+    text: str
+    mod_type: ModType
+    required: bool = True
+    source_hint: SourceHint | None = None
+    notes: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class SocketBlueprint:
+    """Socket configuration requested by the blueprint."""
+
+    total: int | None = None
+    links: Sequence[int] = field(default_factory=tuple)
+    colours: Mapping[str, int] = field(default_factory=dict)
+    notes: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class ItemBlueprint:
+    """High level description of the desired end-state item."""
+
+    name: str | None
+    base_item: str
+    item_class: str | None
+    influences: Sequence[str] = field(default_factory=tuple)
+    required_prefixes: Sequence[ModRequirement] = field(default_factory=tuple)
+    required_suffixes: Sequence[ModRequirement] = field(default_factory=tuple)
+    sockets: SocketBlueprint | None = None
+    notes: Sequence[str] = field(default_factory=tuple)
+
+    def all_required_mods(self) -> Sequence[ModRequirement]:
+        """Return every modifier requirement that must be satisfied."""
+
+        return (*self.required_prefixes, *self.required_suffixes)

--- a/poe_mcp_server/planner.py
+++ b/poe_mcp_server/planner.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from typing import Iterable, List, Sequence
 
 from .datasources import bench_recipes, bosses, essences, harvest
-from .models import CraftingStep
+from .models import CraftingStep, ItemBlueprint, ModRequirement, SocketBlueprint
 
 
 def _format_section(header: str, lines: Iterable[str]) -> str:
@@ -92,3 +92,297 @@ def assemble_crafting_plan(actions: Sequence[str]) -> List[CraftingStep]:
         enriched_steps.append(CraftingStep(action=base_text, instruction=instruction, metadata=metadata))
 
     return enriched_steps
+
+
+@dataclass(frozen=True)
+class _ModClassification:
+    """Intermediate structure describing how to satisfy a modifier."""
+
+    mod: ModRequirement
+    kind: str
+    matches: Sequence[object]
+    search_terms: Sequence[str]
+
+
+def _search_matches(searcher, terms: Sequence[str]) -> Sequence[object]:
+    seen: set[str] = set()
+    for term in terms:
+        cleaned = term.strip()
+        lowered = cleaned.lower()
+        if not cleaned or lowered in seen:
+            continue
+        seen.add(lowered)
+        results = searcher(cleaned)
+        if results:
+            return results
+    return ()
+
+
+def _classify_mod(blueprint: ItemBlueprint, mod: ModRequirement) -> _ModClassification:
+    if mod.source_hint and mod.source_hint.kind == "influence":
+        return _ModClassification(mod=mod, kind="influence", matches=tuple(blueprint.influences), search_terms=())
+
+    hint_kind = mod.source_hint.kind if mod.source_hint else None
+    terms: List[str] = []
+    if mod.source_hint and mod.source_hint.detail:
+        terms.append(mod.source_hint.detail)
+    terms.append(mod.text)
+
+    priority: List[str] = []
+    if hint_kind in {"essence", "harvest", "bench"}:
+        priority.append(hint_kind)
+    for default in ("essence", "harvest", "bench"):
+        if default not in priority:
+            priority.append(default)
+
+    for kind in priority:
+        if kind == "essence":
+            matches = _search_matches(essences.find, terms)
+        elif kind == "harvest":
+            matches = _search_matches(harvest.find, terms)
+        else:  # bench
+            matches = _search_matches(bench_recipes.find, terms)
+        if matches:
+            return _ModClassification(mod=mod, kind=kind, matches=matches, search_terms=tuple(terms))
+
+    if blueprint.influences:
+        term_blob = " ".join(terms).lower()
+        if any(influence.lower() in term_blob for influence in blueprint.influences):
+            return _ModClassification(
+                mod=mod,
+                kind="influence",
+                matches=tuple(blueprint.influences),
+                search_terms=tuple(terms),
+            )
+
+    return _ModClassification(mod=mod, kind="unresolved", matches=(), search_terms=tuple(terms))
+
+
+def _describe_socket_plan(sockets: SocketBlueprint) -> str:
+    parts: List[str] = []
+    if sockets.total:
+        parts.append(f"{sockets.total} sockets")
+    if sockets.links:
+        link = max(sockets.links)
+        parts.append(f"{link}-link")
+    if sockets.colours:
+        colour_desc = ", ".join(f"{colour}:{amount}" for colour, amount in sockets.colours.items())
+        parts.append(f"colours [{colour_desc}]")
+    if sockets.notes:
+        parts.extend(sockets.notes)
+    return ", ".join(parts) if parts else "default sockets"
+
+
+def _plan_for_blueprint(blueprint: ItemBlueprint) -> List[CraftingStep]:
+    steps: List[CraftingStep] = []
+
+    base_metadata: dict[str, object] = {
+        "type": "base_item",
+        "base_item": blueprint.base_item,
+    }
+    if blueprint.name:
+        base_metadata["item_name"] = blueprint.name
+    if blueprint.item_class:
+        base_metadata["item_class"] = blueprint.item_class
+    if blueprint.influences:
+        base_metadata["influences"] = list(blueprint.influences)
+    if blueprint.notes:
+        base_metadata["blueprint_notes"] = list(blueprint.notes)
+
+    base_instruction = [f"Start with a {blueprint.base_item}."]
+    if blueprint.influences:
+        influences = ", ".join(blueprint.influences)
+        base_instruction.append(f"Prefer a base that already has {influences} influence.")
+    if blueprint.notes:
+        base_instruction.extend(blueprint.notes)
+
+    steps.append(
+        CraftingStep(
+            action=f"Acquire {blueprint.base_item}",
+            instruction="\n".join(base_instruction),
+            metadata=base_metadata,
+        )
+    )
+
+    if blueprint.sockets:
+        socket_instruction: List[str] = [
+            f"Target socket layout: {_describe_socket_plan(blueprint.sockets)}."
+        ]
+        socket_metadata: dict[str, object] = {
+            "type": "sockets",
+            "requested": asdict(blueprint.sockets),
+        }
+        bench_matches = ()
+        if blueprint.sockets.links:
+            bench_matches = bench_recipes.find(f"Link {max(blueprint.sockets.links)} sockets")
+        elif blueprint.sockets.total:
+            bench_matches = bench_recipes.find(f"{blueprint.sockets.total} sockets")
+        if bench_matches:
+            socket_metadata["bench_recipes"] = [asdict(recipe) for recipe in bench_matches[:3]]
+            socket_instruction.append("Use the crafting bench or Vorici in Research to hit the link target early.")
+        steps.append(
+            CraftingStep(
+                action="Configure sockets",
+                instruction="\n".join(socket_instruction),
+                metadata=socket_metadata,
+            )
+        )
+
+    classifications = [_classify_mod(blueprint, mod) for mod in blueprint.all_required_mods()]
+
+    essence_buckets: dict[str, dict[str, object]] = {}
+    harvest_steps: List[tuple[_ModClassification, harvest.HarvestCraft]] = []
+    bench_steps: List[tuple[_ModClassification, bench_recipes.BenchRecipe]] = []
+    influence_mods: List[_ModClassification] = []
+    unresolved_mods: List[_ModClassification] = []
+
+    for classification in classifications:
+        if classification.kind == "essence" and classification.matches:
+            essence = classification.matches[0]
+            key = getattr(essence, "identifier", classification.search_terms[0] if classification.search_terms else classification.mod.text)
+            bucket = essence_buckets.setdefault(
+                key,
+                {
+                    "essence": essence,
+                    "mods": [],
+                    "all_matches": classification.matches,
+                },
+            )
+            bucket["mods"].append(classification.mod)
+        elif classification.kind == "harvest" and classification.matches:
+            harvest_steps.append((classification, classification.matches[0]))
+        elif classification.kind == "bench" and classification.matches:
+            bench_steps.append((classification, classification.matches[0]))
+        elif classification.kind == "influence":
+            influence_mods.append(classification)
+        else:
+            unresolved_mods.append(classification)
+
+    if influence_mods:
+        mod_texts = [entry.mod.text for entry in influence_mods]
+        influence_instruction = [
+            "The following modifiers require influenced bases or slams:",
+            "- " + "\n- ".join(mod_texts),
+            "Use Awakener's Orbs, influence-specific Exalted Orbs, or trade to secure these mods.",
+        ]
+        metadata: dict[str, object] = {
+            "type": "influence",
+            "covers_mods": mod_texts,
+        }
+        if blueprint.influences:
+            metadata["influences"] = list(blueprint.influences)
+            influence_instruction.insert(1, f"Relevant influences: {', '.join(blueprint.influences)}.")
+        steps.append(
+            CraftingStep(
+                action="Handle influence-exclusive mods",
+                instruction="\n".join(influence_instruction),
+                metadata=metadata,
+            )
+        )
+
+    for bucket in essence_buckets.values():
+        essence = bucket["essence"]
+        mods = bucket["mods"]
+        mod_texts = [mod.text for mod in mods]
+        instruction_lines = [
+            f"Apply {getattr(essence, 'name', 'the selected essence')} to guarantee: {', '.join(mod_texts)}.",
+            "Do this before bench crafts to keep modification options open.",
+        ]
+        metadata = {
+            "type": "essence",
+            "covers_mods": mod_texts,
+            "essence": asdict(essence) if hasattr(essence, "identifier") else essence,
+        }
+        if bucket["all_matches"]:
+            metadata["candidates"] = [
+                asdict(match) if hasattr(match, "identifier") else match for match in bucket["all_matches"]
+            ]
+        steps.append(
+            CraftingStep(
+                action=f"Apply {getattr(essence, 'name', 'essence')}",
+                instruction="\n".join(instruction_lines),
+                metadata=metadata,
+            )
+        )
+
+    for classification, craft in harvest_steps:
+        mod = classification.mod
+        mod_texts = [mod.text]
+        description = craft.description[0] if craft.description else craft.identifier
+        instruction_lines = [
+            f"Use Harvest option '{description}' to secure {mod.text}.",
+            "Aim to complete essence applications before this step to reduce random outcomes.",
+        ]
+        metadata = {
+            "type": "harvest",
+            "covers_mods": mod_texts,
+            "harvest_crafts": [asdict(craft)] + [
+                asdict(extra) for extra in classification.matches[1:3]
+                if hasattr(extra, "identifier")
+            ],
+        }
+        steps.append(
+            CraftingStep(
+                action=f"Harvest craft for {mod.text}",
+                instruction="\n".join(instruction_lines),
+                metadata=metadata,
+            )
+        )
+
+    for classification, recipe in bench_steps:
+        mod = classification.mod
+        mod_texts = [mod.text]
+        instruction_lines = [f"Use the crafting bench to craft '{recipe.display}'."]
+        if mod.mod_type == "suffix":
+            instruction_lines.append("Apply this craft last so a suffix remains open for other manipulations.")
+        if mod.notes:
+            instruction_lines.extend(mod.notes)
+        metadata: dict[str, object] = {
+            "type": "bench",
+            "covers_mods": mod_texts,
+            "bench_recipe": asdict(recipe),
+        }
+        if mod.mod_type == "suffix":
+            metadata["consumes_suffix"] = True
+        steps.append(
+            CraftingStep(
+                action=f"Bench craft: {recipe.display}",
+                instruction="\n".join(instruction_lines),
+                metadata=metadata,
+            )
+        )
+
+    for classification in unresolved_mods:
+        mod = classification.mod
+        instruction_lines = [
+            f"No curated recipe was found for '{mod.text}'.",
+            "Consider fossil crafting, eldritch implicits, or trading to obtain this modifier.",
+        ]
+        metadata = {
+            "type": "gap",
+            "covers_mods": [mod.text],
+            "missing_source": True,
+        }
+        if classification.search_terms:
+            metadata["search_terms"] = list(classification.search_terms)
+        if mod.notes:
+            instruction_lines.extend(mod.notes)
+            metadata["notes"] = list(mod.notes)
+        steps.append(
+            CraftingStep(
+                action=f"Research sourcing for '{mod.text}'",
+                instruction="\n".join(instruction_lines),
+                metadata=metadata,
+            )
+        )
+
+    return steps
+
+
+def assemble_plan_from_pob(items: Sequence[ItemBlueprint]) -> List[CraftingStep]:
+    """Convert PoB item blueprints into a sequenced list of crafting steps."""
+
+    plan: List[CraftingStep] = []
+    for blueprint in items:
+        plan.extend(_plan_for_blueprint(blueprint))
+    return plan

--- a/tests/test_pob_planner.py
+++ b/tests/test_pob_planner.py
@@ -1,0 +1,112 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from poe_mcp_server.models import (
+    ItemBlueprint,
+    ModRequirement,
+    SocketBlueprint,
+    SourceHint,
+)
+from poe_mcp_server.planner import assemble_plan_from_pob
+
+
+@pytest.fixture()
+def sample_blueprint() -> ItemBlueprint:
+    return ItemBlueprint(
+        name="Example Boots",
+        base_item="Two-Toned Boots",
+        item_class="Armour",
+        influences=("Hunter",),
+        sockets=SocketBlueprint(total=4, links=(4,), colours={"G": 2, "R": 1, "B": 1}),
+        required_prefixes=(
+            ModRequirement(
+                text="+70 to maximum Life",
+                mod_type="prefix",
+                source_hint=SourceHint(kind="essence", detail="Deafening Essence of Greed"),
+            ),
+            ModRequirement(
+                text="+1 to Level of all Chaos Skill Gems",
+                mod_type="prefix",
+                source_hint=SourceHint(kind="influence", detail="Hunter"),
+            ),
+        ),
+        required_suffixes=(
+            ModRequirement(
+                text="Movement Speed",
+                mod_type="suffix",
+                source_hint=SourceHint(kind="bench", detail="Movement Speed"),
+            ),
+            ModRequirement(
+                text="Lightning Resistance",
+                mod_type="suffix",
+                source_hint=SourceHint(kind="harvest", detail="Lightning Resistance"),
+            ),
+            ModRequirement(
+                text="Totally made up mod",
+                mod_type="suffix",
+            ),
+        ),
+    )
+
+
+def test_assemble_plan_from_pob(sample_blueprint: ItemBlueprint) -> None:
+    plan = assemble_plan_from_pob([sample_blueprint])
+
+    assert plan[0].action == "Acquire Two-Toned Boots"
+    actions = [step.action for step in plan]
+    assert "Configure sockets" in actions
+
+    coverage: set[str] = set()
+    essence_step = harvest_step = bench_step = influence_step = gap_step = None
+    for step in plan:
+        coverage.update(step.metadata.get("covers_mods", []))
+        step_type = step.metadata.get("type")
+        if step_type == "essence":
+            essence_step = step
+        elif step_type == "harvest":
+            harvest_step = step
+        elif step_type == "bench":
+            bench_step = step
+        elif step_type == "influence":
+            influence_step = step
+        elif step_type == "gap":
+            gap_step = step
+
+    expected_mods = {
+        "+70 to maximum Life",
+        "+1 to Level of all Chaos Skill Gems",
+        "Movement Speed",
+        "Lightning Resistance",
+        "Totally made up mod",
+    }
+    assert coverage == expected_mods
+
+    assert influence_step is not None
+    assert "+1 to Level of all Chaos Skill Gems" in influence_step.metadata["covers_mods"]
+
+    assert essence_step is not None
+    assert essence_step.metadata["essence"]["name"] == "Deafening Essence of Greed"
+    assert "+70 to maximum Life" in essence_step.metadata["covers_mods"]
+
+    assert harvest_step is not None
+    assert any(
+        "Lightning" in line for line in harvest_step.metadata["harvest_crafts"][0]["description"]
+    )
+
+    assert bench_step is not None
+    assert bench_step.metadata.get("consumes_suffix") is True
+    assert "Movement Speed" in bench_step.metadata["covers_mods"]
+
+    assert gap_step is not None
+    assert gap_step.metadata.get("missing_source") is True
+
+    essence_index = actions.index(essence_step.action)
+    harvest_index = actions.index(harvest_step.action)
+    bench_index = actions.index(bench_step.action)
+
+    assert essence_index < bench_index
+    assert harvest_index < bench_index


### PR DESCRIPTION
## Summary
- add dataclasses describing PoB item blueprints, sockets, and modifier requirements
- implement `assemble_plan_from_pob` to choose essence, harvest, bench, and influence steps with sequencing heuristics
- record an integration test that exercises the new planner and harden essence search against nested metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda677d8d08331b6cac0ae67b48749