### PR TITLE
Add fossil planning support

### DIFF
--- a/data/fossils.json
+++ b/data/fossils.json
@@ -1,0 +1,13870 @@
+{
+  "fossils": [
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreLightning",
+        "GreatlyMoreLightning"
+      ],
+      "descriptions": [
+        "More Chaos modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingChaos",
+      "mod_texts": [],
+      "name": "Aberrant Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 1000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "LessCaster"
+      ],
+      "descriptions": [
+        "More Caster modifiers",
+        "Fewer Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingCasterMods",
+      "mod_texts": [],
+      "name": "Aetheric Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 15
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 1000)",
+        "Decreases chance of attack modifiers (weight 15)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Corrupted\r\nHas a Corrupted implicit modifier"
+      ],
+      "forbidden_tags": [
+        "heist_contract",
+        "heist_blueprint",
+        "heist_equipment"
+      ],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingVaal",
+      "mod_texts": [],
+      "name": "Bloodstained Fossil",
+      "negative_mod_weights": [],
+      "notes": [],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "More Minion, Aura or Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingMinionsAuras",
+      "mod_texts": [],
+      "name": "Bound Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "Increases chance of minion modifiers (weight 1000)",
+        "Increases chance of aura modifiers (weight 1000)",
+        "Increases chance of curse modifiers (weight 1000)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 1000
+        },
+        {
+          "tag": "aura",
+          "weight": 1000
+        },
+        {
+          "tag": "curse",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreElemental",
+        "GreatlyMoreElemental"
+      ],
+      "descriptions": [
+        "More Physical Ailment or Chaos Ailment modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingBleedPoison",
+      "mod_texts": [],
+      "name": "Corroded Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of bleed modifiers (weight 1000)",
+        "Increases chance of poison modifiers (weight 1000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "bleed",
+          "weight": 1000
+        },
+        {
+          "tag": "poison",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreAttribute",
+        "GreatlyMoreAttribute"
+      ],
+      "descriptions": [
+        "More Critical modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingEnchant",
+      "mod_texts": [],
+      "name": "Deft Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 1000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreLife",
+        "GreatlyMoreLife"
+      ],
+      "descriptions": [
+        "More Defence modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingDefences",
+      "mod_texts": [],
+      "name": "Dense Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 1000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "More Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingGemLevel",
+      "mod_texts": [
+        "Adds: +1 to Level of Socketed Strength Gems",
+        "Adds: +1 to Level of Socketed Dexterity Gems",
+        "Adds: +1 to Level of Socketed Intelligence Gems"
+      ],
+      "name": "Faceted Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "Increases chance of gem modifiers (weight 1000)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Creates a split copy"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingMirror",
+      "mod_texts": [],
+      "name": "Fractured Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "Mirrors the item"
+      ],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreFire",
+        "GreatlyMoreFire"
+      ],
+      "descriptions": [
+        "More Cold modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingCold",
+      "mod_texts": [],
+      "name": "Frigid Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 1000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreCritical",
+        "GreatlyMoreCritical"
+      ],
+      "descriptions": [
+        "More Attribute modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingSockets",
+      "mod_texts": [],
+      "name": "Fundamental Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 1000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Item is overvalued by vendors"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingSellPrice",
+      "mod_texts": [
+        "Vendor: Item sells for much more to vendors"
+      ],
+      "name": "Gilded Fossil",
+      "negative_mod_weights": [],
+      "notes": [],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [
+        "weapon",
+        "body_armour",
+        "gloves",
+        "boots",
+        "helmet",
+        "shield",
+        "amulet",
+        "belt",
+        "ring",
+        "quiver"
+      ],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Has a Corrupt Essence modifier"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingCorruptEssence",
+      "mod_texts": [],
+      "name": "Glyphic Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "100% chance to add a corrupted Essence modifier"
+      ],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [
+        "weapon",
+        "helmet",
+        "boots",
+        "gloves",
+        "body_armour"
+      ],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Has an Abyssal socket"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingAbyss",
+      "mod_texts": [
+        "Forces: Has 1 Abyssal Socket"
+      ],
+      "name": "Hollow Fossil",
+      "negative_mod_weights": [],
+      "notes": [],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreChaos",
+        "GreatlyMoreChaos"
+      ],
+      "descriptions": [
+        "More Physical modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingPhysical",
+      "mod_texts": [],
+      "name": "Jagged Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 1000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreSpeed",
+        "GreatlyMoreSpeed"
+      ],
+      "descriptions": [
+        "More Mana modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingMana",
+      "mod_texts": [],
+      "name": "Lucent Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 1000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome1",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome10",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome100",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome101",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome102",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome103",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome104",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome105",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome106",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome107",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome108",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome109",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome11",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome110",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome111",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome112",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome113",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome114",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome115",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome116",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome117",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome118",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome119",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome12",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Lightning modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome120",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome121",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome122",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome123",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome124",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome125",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome126",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome127",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome128",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome129",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome13",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome130",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome131",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome132",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome133",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome134",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome135",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome136",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome137",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome138",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome139",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome14",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Life modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome140",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome141",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome142",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome143",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome144",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome145",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome146",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome147",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome148",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome149",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome15",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome150",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome151",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome152",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome153",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome154",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome155",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome156",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome157",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome158",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome159",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome16",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Gem modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome160",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of gem modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome161",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome162",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome163",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome164",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome165",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome166",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome167",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome168",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome169",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome17",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome170",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome171",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome172",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome173",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome174",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome175",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome176",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome177",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome178",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome179",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome18",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Fire modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome180",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome181",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome182",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome183",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome184",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome185",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome186",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome187",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome188",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome189",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome19",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome190",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome191",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome192",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome193",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome194",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome195",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome196",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome197",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome198",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome199",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome2",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome20",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Elemental modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome200",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome201",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome202",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome203",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome204",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome205",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome206",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome207",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome208",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome209",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome21",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome210",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome211",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome212",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome213",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome214",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome215",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome216",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome217",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome218",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome219",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome22",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Defences modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome220",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of defences modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome221",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome222",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome223",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome224",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome225",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome226",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome227",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome228",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome229",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome23",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome230",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome231",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome232",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome233",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome234",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome235",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome236",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome237",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome238",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome239",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome24",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Damage modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome240",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of damage modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome241",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome242",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome243",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome244",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome245",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome246",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome247",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome248",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome249",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome25",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome250",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome251",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome252",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome253",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome254",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome255",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome256",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome257",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome258",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome259",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome26",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Curse modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome260",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of curse modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome261",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome262",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome263",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome264",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome265",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome266",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome267",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome268",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome269",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome27",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome270",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome271",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome272",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome273",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome274",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome275",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome276",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome277",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome278",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome279",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome28",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Critical modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome280",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of critical modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome281",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome282",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome283",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome284",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome285",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome286",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome287",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome288",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome289",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome29",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome290",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome291",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome292",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome293",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome294",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome295",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome296",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome297",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome298",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome299",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome3",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome30",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Cold modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome300",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of cold modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome301",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome302",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome303",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome304",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome305",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome306",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome307",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome308",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome309",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome31",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome310",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome311",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome312",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome313",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome314",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome315",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome316",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome317",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome318",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome319",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome32",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Chaos modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome320",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of chaos modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome321",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome322",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome323",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome324",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome325",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome326",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome327",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome328",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome329",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome33",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome330",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome331",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome332",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome333",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome334",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome335",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome336",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome337",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome338",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome339",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome34",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Caster modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome340",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of caster modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome341",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome342",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome343",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome344",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome345",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome346",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome347",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome348",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome349",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome35",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome350",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome351",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome352",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome353",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome354",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome355",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome356",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome357",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome358",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome359",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome36",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Aura modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome360",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of aura modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome361",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome362",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome363",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome364",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome365",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome366",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome367",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome368",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome369",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome37",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome370",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome371",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome372",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome373",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome374",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome375",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome376",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome377",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome378",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome379",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome38",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Attribute modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome380",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attribute modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome381",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome382",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome383",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome384",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome385",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome386",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome387",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome388",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome389",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome39",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome390",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome391",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome392",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome393",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome394",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome395",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome396",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome397",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome398",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome399",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome4",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Resistance modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome40",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of resistance modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Attack modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome400",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome401",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome402",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome403",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome404",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome405",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome406",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome407",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome408",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome409",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome41",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome410",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome411",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome412",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome413",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome414",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome415",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome416",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome417",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome418",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome419",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome42",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Ailment modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome420",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of ailment modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome43",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome44",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome45",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome46",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome47",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome48",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome49",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome5",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome50",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome51",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome52",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome53",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome54",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome55",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome56",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome57",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome58",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome59",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome6",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Physical modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome60",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of physical modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome61",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome62",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome63",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMana",
+        "MoreMana"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome64",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome65",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome66",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome67",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome68",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome69",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome7",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome70",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome71",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome72",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome73",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome74",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome75",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome76",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome77",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome78",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome79",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome8",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAilment",
+        "MoreAilment",
+        "MoreBleedPoison"
+      ],
+      "descriptions": [
+        "Greatly more Minion modifiers",
+        "No Ailment modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome80",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "ailment",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of minion modifiers (weight 3000)",
+        "Decreases chance of ailment modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreSpeed",
+        "MoreSpeed"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Speed modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome81",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of speed modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreResistance",
+        "MoreResistance"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Resistance modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome82",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "resistance",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of resistance modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMorePhysical",
+        "MorePhysical"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome83",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreMinion",
+        "MoreMinion"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Minion modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome84",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "minion",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of minion modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLightning",
+        "MoreLightning"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Lightning modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome85",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of lightning modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreLife",
+        "MoreLife"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Life modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome86",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of life modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreGem",
+        "MoreGem"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Gem modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome87",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "gem",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of gem modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreFire",
+        "MoreFire"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Fire modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome88",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of fire modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome89",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreElemental",
+        "MoreElemental"
+      ],
+      "descriptions": [
+        "Greatly more Speed modifiers",
+        "No Elemental modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome9",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 3000)",
+        "Decreases chance of elemental modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDefences",
+        "MoreDefences"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome90",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreDamage",
+        "MoreDamage"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Damage modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome91",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "damage",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of damage modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCurse",
+        "MoreCurse"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Curse modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome92",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "curse",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of curse modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCritical",
+        "MoreCritical"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Critical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome93",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "critical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of critical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCold",
+        "MoreCold"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome94",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreChaos",
+        "MoreChaos"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Chaos modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome95",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "chaos",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of chaos modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreCaster",
+        "MoreCaster",
+        "LessCaster"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome96",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of caster modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAura",
+        "MoreAura"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Aura modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome97",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "aura",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of aura modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttribute",
+        "MoreAttribute"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Attribute modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome98",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attribute",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of attribute modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "GreatlyMoreAttack",
+        "MoreAttack",
+        "LessAttack"
+      ],
+      "descriptions": [
+        "Greatly more Mana modifiers",
+        "No Attack modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/RandomFossilOutcome99",
+      "mod_texts": [],
+      "name": "",
+      "negative_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of mana modifiers (weight 3000)",
+        "Decreases chance of attack modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 3000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MorePhysical",
+        "GreatlyMorePhysical"
+      ],
+      "descriptions": [
+        "More Lightning modifiers",
+        "No Physical modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingLightning",
+      "mod_texts": [],
+      "name": "Metallic Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "physical",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of lightning modifiers (weight 1000)",
+        "Decreases chance of physical modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "lightning",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [
+        "weapon",
+        "body_armour",
+        "gloves",
+        "boots",
+        "helmet",
+        "shield",
+        "map"
+      ],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Improved Quality"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingQuality",
+      "mod_texts": [],
+      "name": "Perfect Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "Rerolls item quality (15-30)"
+      ],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreBleedPoison",
+        "GreatlyMoreAilment"
+      ],
+      "descriptions": [
+        "More Elemental modifiers",
+        "No Physical Ailment or Chaos Ailment Modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingElemental",
+      "mod_texts": [],
+      "name": "Prismatic Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "bleed",
+          "weight": 0
+        },
+        {
+          "tag": "poison",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of elemental modifiers (weight 600)",
+        "Decreases chance of bleed modifiers (weight 0)",
+        "Decreases chance of poison modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "elemental",
+          "weight": 600
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreDefences",
+        "GreatlyMoreDefences"
+      ],
+      "descriptions": [
+        "More Life modifiers",
+        "No Defence modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingLife",
+      "mod_texts": [],
+      "name": "Pristine Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "defences",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of life modifiers (weight 1000)",
+        "Decreases chance of defences modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "life",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Numeric modifier values are lucky\r\nHigh Level modifiers are more common"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingLuckyModRolls",
+      "mod_texts": [],
+      "name": "Sanctified Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "Rolls values Lucky"
+      ],
+      "positive_mod_weights": []
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreCold",
+        "GreatlyMoreCold"
+      ],
+      "descriptions": [
+        "More Fire modifiers",
+        "No Cold modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingFire",
+      "mod_texts": [],
+      "name": "Scorched Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "cold",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of fire modifiers (weight 1000)",
+        "Decreases chance of cold modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "fire",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "LessAttack"
+      ],
+      "descriptions": [
+        "More Attack modifiers",
+        "Fewer Caster modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingAttackMods",
+      "mod_texts": [],
+      "name": "Serrated Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "caster",
+          "weight": 15
+        }
+      ],
+      "notes": [
+        "Increases chance of attack modifiers (weight 1000)",
+        "Decreases chance of caster modifiers (weight 15)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "attack",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [
+        "MoreMana",
+        "GreatlyMoreMana"
+      ],
+      "descriptions": [
+        "More Speed modifiers",
+        "No Mana modifiers"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingSpeed",
+      "mod_texts": [],
+      "name": "Shuddering Fossil",
+      "negative_mod_weights": [
+        {
+          "tag": "mana",
+          "weight": 0
+        }
+      ],
+      "notes": [
+        "Increases chance of speed modifiers (weight 1000)",
+        "Decreases chance of mana modifiers (weight 0)"
+      ],
+      "positive_mod_weights": [
+        {
+          "tag": "speed",
+          "weight": 1000
+        }
+      ]
+    },
+    {
+      "allowed_tags": [],
+      "blocked_descriptions": [],
+      "descriptions": [
+        "Random effects revealed when resonator is fully socketed"
+      ],
+      "forbidden_tags": [],
+      "identifier": "Metadata/Items/Currency/CurrencyDelveCraftingRandom",
+      "mod_texts": [
+        "Adds: +1 to Level of Socketed Strength Gems",
+        "Adds: +1 to Level of Socketed Dexterity Gems",
+        "Adds: +1 to Level of Socketed Intelligence Gems",
+        "Adds: Non-Aura Vaal Skills require -20% increased Souls Per Use",
+        "Adds: Non-Aura Vaal Skills require -40% increased Souls Per Use",
+        "Adds: 5-8% chance to gain an additional Vaal Soul on Kill",
+        "Adds: 80-120% increased Vaal Skill Critical Strike Chance",
+        "Adds: 15-25% increased Vaal Skill Effect Duration",
+        "Adds: 20-40% increased Damage with Vaal Skills",
+        "Adds: 3-5% chance to gain an additional Vaal Soul on Kill",
+        "Adds: Has 1 Abyssal Socket"
+      ],
+      "name": "Tangled Fossil",
+      "negative_mod_weights": [],
+      "notes": [
+        "10% chance to add a corrupted Essence modifier"
+      ],
+      "positive_mod_weights": []
+    }
+  ],
+  "resonators": [
+    {
+      "allowed_fossils": [],
+      "description": "Upgrades a normal item to a rare item",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyUpgrade2",
+      "name": "Potent Alchemical Resonator",
+      "notes": [
+        "Supports up to 2 fossils"
+      ],
+      "sockets": 2
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Reforges a rare item with new random modifiers",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyReroll2",
+      "name": "Potent Chaotic Resonator",
+      "notes": [
+        "Supports up to 2 fossils"
+      ],
+      "sockets": 2
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Upgrades a normal item to a rare item",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyUpgrade3",
+      "name": "Powerful Alchemical Resonator",
+      "notes": [
+        "Supports up to 3 fossils"
+      ],
+      "sockets": 3
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Reforges a rare item with new random modifiers",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyReroll3",
+      "name": "Powerful Chaotic Resonator",
+      "notes": [
+        "Supports up to 3 fossils"
+      ],
+      "sockets": 3
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Upgrades a normal item to a rare item",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyUpgrade4",
+      "name": "Prime Alchemical Resonator",
+      "notes": [
+        "Supports up to 4 fossils"
+      ],
+      "sockets": 4
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Reforges a rare item with new random modifiers",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyReroll4",
+      "name": "Prime Chaotic Resonator",
+      "notes": [
+        "Supports up to 4 fossils"
+      ],
+      "sockets": 4
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Upgrades a normal item to a rare item",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyUpgrade1",
+      "name": "Primitive Alchemical Resonator",
+      "notes": [
+        "Supports up to 1 fossil"
+      ],
+      "sockets": 1
+    },
+    {
+      "allowed_fossils": [],
+      "description": "Reforges a rare item with new random modifiers",
+      "effects": [],
+      "identifier": "Metadata/Items/Delve/DelveSocketableCurrencyReroll1",
+      "name": "Primitive Chaotic Resonator",
+      "notes": [
+        "Supports up to 1 fossil"
+      ],
+      "sockets": 1
+    }
+  ]
+}

--- a/poe_mcp_server/datasources/__init__.py
+++ b/poe_mcp_server/datasources/__init__.py
@@ -1,10 +1,11 @@
 """Curated knowledge base loaders for Path of Exile data."""
 
-from . import bosses, bench_recipes, essences, harvest
+from . import bosses, bench_recipes, essences, fossils, harvest
 
 __all__ = [
     "bosses",
     "bench_recipes",
     "essences",
+    "fossils",
     "harvest",
 ]

--- a/poe_mcp_server/datasources/fossils.py
+++ b/poe_mcp_server/datasources/fossils.py
@@ -1,0 +1,284 @@
+"""Fossil and resonator metadata loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List, Sequence
+
+from .utils import load_json
+
+
+@dataclass(frozen=True)
+class TagWeight:
+    """Modifier weight adjustment for a fossil."""
+
+    tag: str
+    weight: float
+
+
+@dataclass(frozen=True)
+class Fossil:
+    """Curated fossil metadata."""
+
+    identifier: str
+    name: str
+    descriptions: Sequence[str]
+    blocked_descriptions: Sequence[str]
+    mod_texts: Sequence[str]
+    notes: Sequence[str]
+    allowed_tags: Sequence[str]
+    forbidden_tags: Sequence[str]
+    positive_mod_weights: Sequence[TagWeight]
+    negative_mod_weights: Sequence[TagWeight]
+
+
+@dataclass(frozen=True)
+class Resonator:
+    """Curated resonator metadata."""
+
+    identifier: str
+    name: str
+    sockets: int
+    description: str
+    effects: Sequence[str]
+    notes: Sequence[str]
+    allowed_fossils: Sequence[str]
+
+
+@dataclass(frozen=True)
+class SearchResults:
+    """Result container for fossil lookups."""
+
+    fossils: Sequence[Fossil]
+    resonators: Sequence[Resonator]
+
+
+class _FossilIndex:
+    """Index fossils and resonators for keyword search."""
+
+    _STOP_TOKENS = {
+        "a",
+        "an",
+        "and",
+        "apply",
+        "craft",
+        "crafting",
+        "for",
+        "in",
+        "into",
+        "on",
+        "socket",
+        "sockets",
+        "socketed",
+        "the",
+        "to",
+        "use",
+        "using",
+        "with",
+    }
+    _SOCKET_WORDS = {
+        "single": 1,
+        "one": 1,
+        "double": 2,
+        "two": 2,
+        "triple": 3,
+        "three": 3,
+        "quad": 4,
+        "quadruple": 4,
+        "four": 4,
+    }
+
+    def __init__(self) -> None:
+        payload = load_json("fossils.json")
+        fossils_raw = payload.get("fossils", [])
+        resonators_raw = payload.get("resonators", [])
+        self._fossils = [self._build_fossil(entry) for entry in fossils_raw]
+        self._resonators = [self._build_resonator(entry) for entry in resonators_raw]
+
+    @staticmethod
+    def _build_fossil(entry: dict) -> Fossil:
+        def build_weights(values: Iterable[dict]) -> List[TagWeight]:
+            weights: List[TagWeight] = []
+            for item in values:
+                tag = str(item.get("tag", "")).strip()
+                if not tag:
+                    continue
+                raw_weight = item.get("weight", 0)
+                if isinstance(raw_weight, (int, float)):
+                    weight = float(raw_weight)
+                else:
+                    try:
+                        weight = float(raw_weight)
+                    except (TypeError, ValueError):
+                        weight = 0.0
+                weights.append(TagWeight(tag=tag, weight=weight))
+            return weights
+
+        return Fossil(
+            identifier=str(entry.get("identifier", "")),
+            name=str(entry.get("name", "")),
+            descriptions=tuple(str(text) for text in entry.get("descriptions", []) if text),
+            blocked_descriptions=tuple(str(text) for text in entry.get("blocked_descriptions", []) if text),
+            mod_texts=tuple(str(text) for text in entry.get("mod_texts", []) if text),
+            notes=tuple(str(text) for text in entry.get("notes", []) if text),
+            allowed_tags=tuple(str(text) for text in entry.get("allowed_tags", []) if text),
+            forbidden_tags=tuple(str(text) for text in entry.get("forbidden_tags", []) if text),
+            positive_mod_weights=tuple(build_weights(entry.get("positive_mod_weights", []))),
+            negative_mod_weights=tuple(build_weights(entry.get("negative_mod_weights", []))),
+        )
+
+    @staticmethod
+    def _build_resonator(entry: dict) -> Resonator:
+        sockets = entry.get("sockets")
+        if not isinstance(sockets, int):
+            try:
+                sockets = int(sockets)
+            except (TypeError, ValueError):
+                sockets = 0
+        return Resonator(
+            identifier=str(entry.get("identifier", "")),
+            name=str(entry.get("name", "")),
+            sockets=sockets,
+            description=str(entry.get("description", "")),
+            effects=tuple(str(text) for text in entry.get("effects", []) if text),
+            notes=tuple(str(text) for text in entry.get("notes", []) if text),
+            allowed_fossils=tuple(str(text) for text in entry.get("allowed_fossils", []) if text),
+        )
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        cleaned = re.sub(r"[^a-z0-9]+", " ", text.lower())
+        return " ".join(cleaned.split())
+
+    def _tokenise(self, text: str) -> List[str]:
+        return [token for token in self._normalise(text).split() if token]
+
+    def _filter_tokens(self, tokens: Sequence[str], *, drop_socket_words: bool = False) -> List[str]:
+        filtered: List[str] = []
+        for token in tokens:
+            if token in self._STOP_TOKENS:
+                continue
+            if drop_socket_words and token in self._SOCKET_WORDS:
+                continue
+            filtered.append(token)
+        return filtered
+
+    def _contains_tokens(self, haystack: Iterable[str], tokens: Sequence[str]) -> bool:
+        if not tokens:
+            return False
+        normalised = [self._normalise(candidate) for candidate in haystack if candidate]
+        if not normalised:
+            return False
+        for token in tokens:
+            if not any(token in candidate for candidate in normalised):
+                return False
+        return True
+
+    def _parse_socket_hints(self, query: str) -> set[int]:
+        hints: set[int] = set()
+        lowered = query.lower()
+        for match in re.findall(r"(\d+)[\s-]*(?:socket|sock|slot)", lowered):
+            try:
+                hints.add(int(match))
+            except ValueError:
+                continue
+        for word, value in self._SOCKET_WORDS.items():
+            if word in lowered:
+                hints.add(value)
+        return hints
+
+    def search_fossils(self, query: str) -> List[Fossil]:
+        raw_tokens = self._tokenise(query)
+        tokens = self._filter_tokens(raw_tokens)
+        tokens = [
+            token
+            for token in tokens
+            if token not in {"resonator", "resonators"}
+            and token not in self._SOCKET_WORDS
+            and not token.isdigit()
+        ]
+        matches: List[Fossil] = []
+        for fossil in self._fossils:
+            haystack = [
+                fossil.identifier,
+                fossil.name,
+                *fossil.descriptions,
+                *fossil.blocked_descriptions,
+                *fossil.mod_texts,
+                *fossil.notes,
+                *fossil.allowed_tags,
+                *fossil.forbidden_tags,
+                *(weight.tag for weight in fossil.positive_mod_weights),
+                *(weight.tag for weight in fossil.negative_mod_weights),
+            ]
+            if tokens and self._contains_tokens(haystack, tokens):
+                matches.append(fossil)
+        if not matches and ("fossil" in raw_tokens or "fossils" in raw_tokens):
+            matches = list(self._fossils)
+        return matches
+
+    def search_resonators(self, query: str) -> List[Resonator]:
+        raw_tokens = self._tokenise(query)
+        tokens = self._filter_tokens(raw_tokens, drop_socket_words=True)
+        socket_hints = self._parse_socket_hints(query)
+        matches: List[Resonator] = []
+        for resonator in self._resonators:
+            haystack = [
+                resonator.identifier,
+                resonator.name,
+                resonator.description,
+                *resonator.effects,
+                *resonator.notes,
+                *resonator.allowed_fossils,
+                str(resonator.sockets),
+            ]
+            if tokens and self._contains_tokens(haystack, tokens):
+                if socket_hints and resonator.sockets not in socket_hints:
+                    continue
+                matches.append(resonator)
+                continue
+            if socket_hints and resonator.sockets in socket_hints:
+                matches.append(resonator)
+        if not matches and ("resonator" in raw_tokens or "resonators" in raw_tokens):
+            matches = list(self._resonators)
+        return matches
+
+    @property
+    def fossils(self) -> Sequence[Fossil]:
+        return tuple(self._fossils)
+
+    @property
+    def resonators(self) -> Sequence[Resonator]:
+        return tuple(self._resonators)
+
+
+_index: _FossilIndex | None = None
+
+
+def _get_index() -> _FossilIndex:
+    global _index
+    if _index is None:
+        _index = _FossilIndex()
+    return _index
+
+
+def load_fossils() -> Sequence[Fossil]:
+    """Return all curated fossils."""
+
+    return _get_index().fossils
+
+
+def load_resonators() -> Sequence[Resonator]:
+    """Return all curated resonators."""
+
+    return _get_index().resonators
+
+
+def find(query: str) -> SearchResults:
+    """Return fossils and resonators matching *query*."""
+
+    index = _get_index()
+    fossil_hits = index.search_fossils(query)
+    resonator_hits = index.search_resonators(query)
+    return SearchResults(fossils=tuple(fossil_hits), resonators=tuple(resonator_hits))

--- a/poe_mcp_server/planner.py
+++ b/poe_mcp_server/planner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Iterable, List, Sequence
 
-from .datasources import bench_recipes, bosses, essences, harvest
+from .datasources import bench_recipes, bosses, essences, fossils, harvest
 from .models import CraftingStep
 
 
@@ -20,6 +20,23 @@ def _format_costs(costs: Sequence[bench_recipes.BenchCost]) -> str:
     if not costs:
         return "free"
     return ", ".join(f"{cost.amount} {cost.currency}" for cost in costs)
+
+
+def _dedupe_preserve_order(lines: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    ordered: List[str] = []
+    for line in lines:
+        cleaned = line.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        ordered.append(cleaned)
+    return ordered
+
+
+def _format_weight(weight: fossils.TagWeight) -> str:
+    value = int(weight.weight) if float(weight.weight).is_integer() else weight.weight
+    return f"{weight.tag} ({value})"
 
 
 def assemble_crafting_plan(actions: Sequence[str]) -> List[CraftingStep]:
@@ -74,6 +91,73 @@ def assemble_crafting_plan(actions: Sequence[str]) -> List[CraftingStep]:
                 for craft in harvest_hits[:3]
             ]
             section = _format_section("Harvest Options:", lines)
+            if section:
+                instruction_parts.append(section)
+
+        fossil_hits = fossils.find(base_text)
+        fossil_matches = list(fossil_hits.fossils)
+        resonator_matches = list(fossil_hits.resonators)
+        if fossil_matches or resonator_matches:
+            metadata["fossils"] = {
+                "fossils": [asdict(entry) for entry in fossil_matches],
+                "resonators": [asdict(entry) for entry in resonator_matches],
+            }
+            fossil_lines: List[str] = []
+            for fossil_entry in fossil_matches[:3]:
+                effect_parts = _dedupe_preserve_order(
+                    [*fossil_entry.descriptions, *fossil_entry.mod_texts, *fossil_entry.notes]
+                )
+                summary = "; ".join(effect_parts[:4])
+                tag_bits: List[str] = []
+                if fossil_entry.allowed_tags:
+                    tag_bits.append("allows " + ", ".join(fossil_entry.allowed_tags[:4]))
+                if fossil_entry.forbidden_tags:
+                    tag_bits.append("blocks " + ", ".join(fossil_entry.forbidden_tags[:4]))
+                if fossil_entry.positive_mod_weights:
+                    tag_bits.append(
+                        "weights+ "
+                        + ", ".join(_format_weight(weight) for weight in fossil_entry.positive_mod_weights[:3])
+                    )
+                if fossil_entry.negative_mod_weights:
+                    tag_bits.append(
+                        "weights- "
+                        + ", ".join(_format_weight(weight) for weight in fossil_entry.negative_mod_weights[:3])
+                    )
+                details: List[str] = []
+                if summary:
+                    details.append(summary)
+                if tag_bits:
+                    details.append("[" + "; ".join(tag_bits) + "]")
+                line = f"- {fossil_entry.name}"
+                if details:
+                    line += " – " + " | ".join(details)
+                fossil_lines.append(line)
+
+            for resonator_entry in resonator_matches[:3]:
+                effect_parts = _dedupe_preserve_order(
+                    [resonator_entry.description, *resonator_entry.effects, *resonator_entry.notes]
+                )
+                sockets_text = ""
+                if effect_parts and effect_parts[0].lower().startswith("supports up to"):
+                    sockets_text = effect_parts.pop(0)
+                elif resonator_entry.sockets:
+                    sockets_text = (
+                        f"Supports up to {resonator_entry.sockets} fossil"
+                        f"{'s' if resonator_entry.sockets != 1 else ''}"
+                    )
+                details: List[str] = []
+                if sockets_text:
+                    details.append(sockets_text)
+                if effect_parts:
+                    details.append("; ".join(effect_parts[:3]))
+                if resonator_entry.allowed_fossils:
+                    details.append("favours " + ", ".join(resonator_entry.allowed_fossils[:4]))
+                line = f"- {resonator_entry.name}"
+                if details:
+                    line += " – " + " | ".join(part for part in details if part)
+                fossil_lines.append(line)
+
+            section = _format_section("Fossil & Resonator Options:", fossil_lines)
             if section:
                 instruction_parts.append(section)
 


### PR DESCRIPTION
## Summary
- add a sync routine that exports curated fossil and resonator data
- load the new fossil metadata in the server and surface it in the planner output

## Testing
- python scripts/sync_static_data.py --sections fossils --verbose
- python -m compileall poe_mcp_server

------
https://chatgpt.com/codex/tasks/task_e_68cd8b3ad89c8331bb2901254f213ef6