### PR TITLE
Describe essence types in synced data

### DIFF
--- a/data/essences.json
+++ b/data/essences.json
@@ -8,10 +8,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 32,
     "tier": "Remnant of Corruption",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 0
-    }
+    "type": "Remnant of Corruption – Tier 0"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger1",
@@ -22,10 +19,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Anger – Tier 2 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger2",
@@ -36,10 +30,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Anger – Tier 2 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger3",
@@ -50,10 +41,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Anger – Tier 2 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger4",
@@ -64,10 +52,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Anger – Tier 2 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger5",
@@ -78,10 +63,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Anger – Tier 2 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnger6",
@@ -92,10 +74,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Anger – Tier 2 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish1",
@@ -106,10 +85,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Anguish – Tier 4 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish2",
@@ -120,10 +96,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Anguish – Tier 4 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish3",
@@ -134,10 +107,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Anguish – Tier 4 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceAnguish4",
@@ -148,10 +118,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Anguish – Tier 4 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt1",
@@ -162,10 +129,7 @@
     "spawn_level_max": 47,
     "spawn_level_min": 1,
     "tier": "Whispering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Whispering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt2",
@@ -176,10 +140,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt3",
@@ -190,10 +151,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt4",
@@ -204,10 +162,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt5",
@@ -218,10 +173,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt6",
@@ -232,10 +184,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceContempt7",
@@ -246,10 +195,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Contempt – Tier 1 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDelirium1",
@@ -260,10 +206,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Essence of Delirium",
-    "type": {
-      "is_corruption_only": true,
-      "tier": 6
-    }
+    "type": "Essence of Delirium – Tier 6 – Corruption-only"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt1",
@@ -274,10 +217,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Doubt – Tier 3 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt2",
@@ -288,10 +228,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Doubt – Tier 3 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt3",
@@ -302,10 +239,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Doubt – Tier 3 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt4",
@@ -316,10 +250,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Doubt – Tier 3 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDoubt5",
@@ -330,10 +261,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Doubt – Tier 3 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDread1",
@@ -344,10 +272,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Dread – Tier 5 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDread2",
@@ -358,10 +283,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Dread – Tier 5 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceDread3",
@@ -372,10 +294,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Dread – Tier 5 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceEnvy1",
@@ -386,10 +305,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Envy – Tier 5 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceEnvy2",
@@ -400,10 +316,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Envy – Tier 5 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceEnvy3",
@@ -414,10 +327,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Envy – Tier 5 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceFear1",
@@ -428,10 +338,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Fear – Tier 2 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceFear2",
@@ -442,10 +349,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Fear – Tier 2 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceFear3",
@@ -456,10 +360,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Fear – Tier 2 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceFear4",
@@ -470,10 +371,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Fear – Tier 2 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceFear5",
@@ -484,10 +382,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Fear – Tier 2 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceFear6",
@@ -498,10 +393,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Fear – Tier 2 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed1",
@@ -512,10 +404,7 @@
     "spawn_level_max": 47,
     "spawn_level_min": 1,
     "tier": "Whispering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Whispering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed2",
@@ -526,10 +415,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed3",
@@ -540,10 +426,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed4",
@@ -554,10 +437,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed5",
@@ -568,10 +448,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed6",
@@ -582,10 +459,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceGreed7",
@@ -596,10 +470,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Greed – Tier 1 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred1",
@@ -610,10 +481,7 @@
     "spawn_level_max": 47,
     "spawn_level_min": 1,
     "tier": "Whispering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Whispering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred2",
@@ -624,10 +492,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred3",
@@ -638,10 +503,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred4",
@@ -652,10 +514,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred5",
@@ -666,10 +525,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred6",
@@ -680,10 +536,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHatred7",
@@ -694,10 +547,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Hatred – Tier 1 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHorror1",
@@ -708,10 +558,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Essence of Horror",
-    "type": {
-      "is_corruption_only": true,
-      "tier": 6
-    }
+    "type": "Essence of Horror – Tier 6 – Corruption-only"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceHysteria1",
@@ -722,10 +569,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Essence of Hysteria",
-    "type": {
-      "is_corruption_only": true,
-      "tier": 6
-    }
+    "type": "Essence of Hysteria – Tier 6 – Corruption-only"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceInsanity1",
@@ -736,10 +580,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Essence of Insanity",
-    "type": {
-      "is_corruption_only": true,
-      "tier": 6
-    }
+    "type": "Essence of Insanity – Tier 6 – Corruption-only"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing1",
@@ -750,10 +591,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Loathing – Tier 4 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing2",
@@ -764,10 +602,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Loathing – Tier 4 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing3",
@@ -778,10 +613,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Loathing – Tier 4 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceLoathing4",
@@ -792,10 +624,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Loathing – Tier 4 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceMisery1",
@@ -806,10 +635,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Misery – Tier 5 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceMisery2",
@@ -820,10 +646,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Misery – Tier 5 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceMisery3",
@@ -834,10 +657,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Misery – Tier 5 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceRage1",
@@ -848,10 +668,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Rage – Tier 3 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceRage2",
@@ -862,10 +679,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Rage – Tier 3 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceRage3",
@@ -876,10 +690,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Rage – Tier 3 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceRage4",
@@ -890,10 +701,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Rage – Tier 3 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceRage5",
@@ -904,10 +712,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Rage – Tier 3 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceScorn1",
@@ -918,10 +723,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Scorn – Tier 5 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceScorn2",
@@ -932,10 +734,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Scorn – Tier 5 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceScorn3",
@@ -946,10 +745,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 5
-    }
+    "type": "Scorn – Tier 5 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow1",
@@ -960,10 +756,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Sorrow – Tier 2 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow2",
@@ -974,10 +767,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Sorrow – Tier 2 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow3",
@@ -988,10 +778,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Sorrow – Tier 2 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow4",
@@ -1002,10 +789,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Sorrow – Tier 2 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow5",
@@ -1016,10 +800,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Sorrow – Tier 2 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSorrow6",
@@ -1030,10 +811,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Sorrow – Tier 2 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite1",
@@ -1044,10 +822,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Spite – Tier 4 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite2",
@@ -1058,10 +833,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Spite – Tier 4 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite3",
@@ -1072,10 +844,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Spite – Tier 4 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSpite4",
@@ -1086,10 +855,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Spite – Tier 4 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering1",
@@ -1100,10 +866,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Suffering – Tier 3 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering2",
@@ -1114,10 +877,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Suffering – Tier 3 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering3",
@@ -1128,10 +888,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Suffering – Tier 3 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering4",
@@ -1142,10 +899,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Suffering – Tier 3 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceSuffering5",
@@ -1156,10 +910,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Suffering – Tier 3 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment1",
@@ -1170,10 +921,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Torment – Tier 2 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment2",
@@ -1184,10 +932,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Torment – Tier 2 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment3",
@@ -1198,10 +943,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Torment – Tier 2 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment4",
@@ -1212,10 +954,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Torment – Tier 2 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment5",
@@ -1226,10 +965,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Torment – Tier 2 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceTorment6",
@@ -1240,10 +976,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 2
-    }
+    "type": "Torment – Tier 2 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe1",
@@ -1254,10 +987,7 @@
     "spawn_level_max": 47,
     "spawn_level_min": 1,
     "tier": "Whispering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Whispering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe2",
@@ -1268,10 +998,7 @@
     "spawn_level_max": 67,
     "spawn_level_min": 12,
     "tier": "Muttering",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Muttering)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe3",
@@ -1282,10 +1009,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe4",
@@ -1296,10 +1020,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe5",
@@ -1310,10 +1031,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe6",
@@ -1324,10 +1042,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWoe7",
@@ -1338,10 +1053,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 1
-    }
+    "type": "Woe – Tier 1 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath1",
@@ -1352,10 +1064,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 30,
     "tier": "Weeping",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Wrath – Tier 3 (Weeping)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath2",
@@ -1366,10 +1075,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Wrath – Tier 3 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath3",
@@ -1380,10 +1086,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Wrath – Tier 3 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath4",
@@ -1394,10 +1097,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Wrath – Tier 3 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceWrath5",
@@ -1408,10 +1108,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 3
-    }
+    "type": "Wrath – Tier 3 (Deafening)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal1",
@@ -1422,10 +1119,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 48,
     "tier": "Wailing",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Zeal – Tier 4 (Wailing)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal2",
@@ -1436,10 +1130,7 @@
     "spawn_level_max": 100,
     "spawn_level_min": 68,
     "tier": "Screaming",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Zeal – Tier 4 (Screaming)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal3",
@@ -1450,10 +1141,7 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Shrieking",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Zeal – Tier 4 (Shrieking)"
   },
   {
     "identifier": "Metadata/Items/Currency/CurrencyEssenceZeal4",
@@ -1464,9 +1152,6 @@
     "spawn_level_max": 0,
     "spawn_level_min": 0,
     "tier": "Deafening",
-    "type": {
-      "is_corruption_only": false,
-      "tier": 4
-    }
+    "type": "Zeal – Tier 4 (Deafening)"
   }
 ]

--- a/scripts/sync_static_data.py
+++ b/scripts/sync_static_data.py
@@ -196,6 +196,42 @@ def collect_keywords(*values: object) -> List[str]:
     return sorted(terms)
 
 
+def describe_essence_type(name: str, type_info: dict | None) -> str:
+    """Convert the RePoE essence type structure into a readable string."""
+
+    type_info = type_info or {}
+    name = name or ""
+    family = ""
+    tier_label = ""
+    if " Essence of " in name:
+        tier_label, family = name.split(" Essence of ", 1)
+    else:
+        family = name
+    family = family.strip()
+    tier_label = tier_label.strip()
+
+    tier_value = type_info.get("tier")
+    tier_text = ""
+    if isinstance(tier_value, (int, float)):
+        if isinstance(tier_value, float) and tier_value.is_integer():
+            tier_value = int(tier_value)
+        tier_text = f"Tier {tier_value}"
+        if tier_label and tier_label.lower() != family.lower():
+            tier_text += f" ({tier_label})"
+    elif tier_label:
+        tier_text = tier_label
+
+    parts: List[str] = []
+    if family:
+        parts.append(family)
+    if tier_text:
+        parts.append(tier_text)
+    if type_info.get("is_corruption_only"):
+        parts.append("Corruption-only")
+
+    return " – ".join(parts) or "Unknown essence type"
+
+
 def humanise_descriptor(text: str) -> str:
     if not text:
         return ""
@@ -313,13 +349,14 @@ def sync_essence_data(translator: StatTranslator) -> None:
             if mod:
                 mod_texts.extend(translator.translate(mod.get("stats", [])))
         tier = data.get("name", "").split(" Essence ")[0]
+        type_text = describe_essence_type(data.get("name", identifier), data.get("type"))
         curated.append(
             {
                 "identifier": identifier,
                 "name": data.get("name", identifier),
                 "tier": tier,
                 "level": data.get("level", 0),
-                "type": data.get("type", ""),
+                "type": type_text,
                 "mods": mod_texts,
                 "item_level_restriction": data.get("item_level_restriction"),
                 "spawn_level_min": data.get("spawn_level_min"),


### PR DESCRIPTION
## Summary
- derive human-readable essence type descriptions when curating RePoE data
- regenerate the essence dataset so each entry stores the descriptive type string

## Testing
- python scripts/sync_static_data.py --sections essences
- python - <<'PY'
from poe_mcp_server.datasources import essences
essences.find("Anger")
PY


------
https://chatgpt.com/codex/tasks/task_e_68cdaf0122088331aa60deb87eb529d5